### PR TITLE
Fix user onchange handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] 2018-11-20
+### Bugfix
+-  Fixed issue where adding a user onChange handler caused the bindings to break.
+
 ## [1.0.0] 2018-11-12
 ### Release
 - Created initial component library release.

--- a/demo/src/guides/FormsGuide.js
+++ b/demo/src/guides/FormsGuide.js
@@ -134,9 +134,6 @@ class FormsGuide extends Component {
                                             labelText={t(
                                                 'forms.demo.petType.label'
                                             )}
-                                            onChange={e => {
-                                                console.log(e.target.value);
-                                            }}
                                             component={Input}
                                         />
                                         <Form.TextareaController
@@ -145,9 +142,6 @@ class FormsGuide extends Component {
                                             labelText={t(
                                                 'forms.demo.petDescription.label'
                                             )}
-                                            onChange={e => {
-                                                console.log(e.target.value);
-                                            }}
                                             component={TextArea}
                                         />
                                         <Form.SelectController
@@ -167,9 +161,6 @@ class FormsGuide extends Component {
                                             requiredText={t(
                                                 'forms.demo.requiredText'
                                             )}
-                                            onChange={e => {
-                                                console.log(e.target.value);
-                                            }}
                                             component={Select}
                                         >
                                             <option>
@@ -275,9 +266,6 @@ class FormsGuide extends Component {
                                             labelText={t(
                                                 'forms.demo.confirmInfo.label'
                                             )}
-                                            onChange={e => {
-                                                console.log(e.target.value);
-                                            }}
                                             component={Checkbox}
                                         />
 

--- a/demo/src/guides/FormsGuide.js
+++ b/demo/src/guides/FormsGuide.js
@@ -134,6 +134,9 @@ class FormsGuide extends Component {
                                             labelText={t(
                                                 'forms.demo.petType.label'
                                             )}
+                                            onChange={e => {
+                                                console.log(e.target.value);
+                                            }}
                                             component={Input}
                                         />
                                         <Form.TextareaController
@@ -142,6 +145,9 @@ class FormsGuide extends Component {
                                             labelText={t(
                                                 'forms.demo.petDescription.label'
                                             )}
+                                            onChange={e => {
+                                                console.log(e.target.value);
+                                            }}
                                             component={TextArea}
                                         />
                                         <Form.SelectController
@@ -161,6 +167,9 @@ class FormsGuide extends Component {
                                             requiredText={t(
                                                 'forms.demo.requiredText'
                                             )}
+                                            onChange={e => {
+                                                console.log(e.target.value);
+                                            }}
                                             component={Select}
                                         >
                                             <option>
@@ -266,6 +275,9 @@ class FormsGuide extends Component {
                                             labelText={t(
                                                 'forms.demo.confirmInfo.label'
                                             )}
+                                            onChange={e => {
+                                                console.log(e.target.value);
+                                            }}
                                             component={Checkbox}
                                         />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tenon-io/tenon-ui",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Tenon-ui components library",
     "contributors": [
         "Karl Groves <karl@tenon.io>",
@@ -36,7 +36,7 @@
         "watch": "node scripts/test.js --env=jsdom",
         "format-src": "prettier --write src/**/*.{js,scss}",
         "format-demo": "prettier --write demo/**/*.js !demo/dist/**",
-        "format-www": "prettier --write www/**/*.js !www/.cache/** !www/public/**",
+        "format-www": "prettier --write www/**/*.{js,mdx} !www/.cache/** !www/public/**",
         "format": "npm-run-all format-src format-demo format-www",
         "lint": "eslint *.js src",
         "lint-demo": "eslint *.js demo"
@@ -72,10 +72,10 @@
         "node-sass-chokidar": "1.3.3",
         "npm-run-all": "4.1.3",
         "nwb": "0.22.0",
-        "prettier": "1.14.2",
+        "prettier": "1.15.2",
         "prop-types": "15.6.2",
-        "react": "16.6.0",
-        "react-dom": "16.6.0",
+        "react": "16.6.3",
+        "react-dom": "16.6.3",
         "react-i18next": "7.10.1",
         "react-loadable": "5.5.0",
         "react-testing-library": "4.1.5",

--- a/src/modules/forms/tenonForm/CheckboxGroup.js
+++ b/src/modules/forms/tenonForm/CheckboxGroup.js
@@ -72,13 +72,12 @@ const CheckboxGroup = forwardRef(
                         {contentHintText}
                     </span>
                 )}
-                {errorText &&
-                    showError && (
-                        <span className="visually-hidden">
-                            &nbsp;
-                            {errorText}
-                        </span>
-                    )}
+                {errorText && showError && (
+                    <span className="visually-hidden">
+                        &nbsp;
+                        {errorText}
+                    </span>
+                )}
             </legend>
             <FocusCatcher>
                 <ul className="checkbox-container">

--- a/src/modules/forms/tenonForm/FormControllers.js
+++ b/src/modules/forms/tenonForm/FormControllers.js
@@ -270,10 +270,12 @@ class FormController extends Component {
      *
      * @param required {object} props - Object with the given
      * props to configure the input.
+     * @param {SyntheticEvent} onChange - Custome user onChange
+     * event handler.
      *
      * @returns {object}
      */
-    getBaseInputProps = ({ onChange, ...props }) => {
+    getBaseInputProps = (props, onChange) => {
         const {
             name,
             getControlValidity,
@@ -304,11 +306,11 @@ class FormController extends Component {
      * @param {object} props
      * @returns {object}
      */
-    getInputProps = (props = {}) => {
+    getInputProps = ({ onChange, ...props } = {}) => {
         const { name, getControlValue } = this.props;
 
         return {
-            ...this.getBaseInputProps(props),
+            ...this.getBaseInputProps(props, onChange),
             'aria-readonly': props['readOnly'] ? 'true' : null,
             type: 'text',
             value: getControlValue(name),
@@ -360,11 +362,11 @@ class FormController extends Component {
      * @param {object} props
      * @returns {object}
      */
-    getCheckboxProps = (props = {}) => {
+    getCheckboxProps = ({ onChange, ...props } = {}) => {
         const { name, getControlValue } = this.props;
 
         return {
-            ...this.getBaseInputProps(props),
+            ...this.getBaseInputProps(props, onChange),
             type: 'checkbox',
             checked: getControlValue(name),
             ...props

--- a/src/modules/forms/tenonForm/RadioGroup.js
+++ b/src/modules/forms/tenonForm/RadioGroup.js
@@ -68,13 +68,12 @@ const RadioGroup = forwardRef(
                         {contentHintText}
                     </span>
                 )}
-                {errorText &&
-                    showError && (
-                        <span className="visually-hidden">
-                            &nbsp;
-                            {errorText}
-                        </span>
-                    )}
+                {errorText && showError && (
+                    <span className="visually-hidden">
+                        &nbsp;
+                        {errorText}
+                    </span>
+                )}
             </legend>
             <FocusCatcher>
                 <ul className="radio-container">

--- a/src/modules/forms/tenonForm/__tests__/Form.CheckboxController.spec.js
+++ b/src/modules/forms/tenonForm/__tests__/Form.CheckboxController.spec.js
@@ -130,6 +130,54 @@ describe('Form.CheckboxController', () => {
         expect(testInput.attributes.length).toBe(4);
     });
 
+    it('should run a custom onChange handler, when given', () => {
+        let eventValue = '';
+
+        const onChangeSpy = jest.fn(e => {
+            eventValue = e.target.checked;
+        });
+
+        const { getByLabelText, getByTestId } = render(
+            <Form onSubmit={jest.fn()}>
+                {({ formControls }) => (
+                    <div>
+                        {JSON.stringify(formControls)}
+                        <span data-testid="resultContainer">
+                            {formControls.testCheckbox
+                                ? formControls.testCheckbox.value.toString()
+                                : ''}
+                        </span>
+                        <Form.CheckboxController name="testCheckbox">
+                            {({ getCheckboxProps, getLabelProps }) => {
+                                return (
+                                    <div>
+                                        <input
+                                            {...getCheckboxProps({
+                                                onChange: onChangeSpy
+                                            })}
+                                        />
+                                        <label {...getLabelProps()}>
+                                            Test checkbox
+                                        </label>
+                                    </div>
+                                );
+                            }}
+                        </Form.CheckboxController>
+                        <button type="submit">Submit</button>
+                    </div>
+                )}
+            </Form>
+        );
+
+        const input = getByLabelText('Test checkbox');
+
+        fireEvent.click(input);
+
+        expect(getByTestId('resultContainer')).toHaveTextContent('true');
+        expect(onChangeSpy).toHaveBeenCalled();
+        expect(eventValue).toBe(true);
+    });
+
     it('should validate a checkbox and set an error text when appropriate', () => {
         const { getByLabelText, getByTestId, getByText } = render(
             <Form onSubmit={jest.fn()}>

--- a/src/modules/forms/tenonForm/__tests__/Form.CheckboxGroupController.spec.js
+++ b/src/modules/forms/tenonForm/__tests__/Form.CheckboxGroupController.spec.js
@@ -190,6 +190,58 @@ describe('Form.CheckboxGroupController', () => {
         expect(submitData).toEqual({ textCheck: ['two'] });
     });
 
+    it('should run a custom onChange handler, when given', () => {
+        let eventValue = '';
+
+        let submitData = null;
+
+        const onChangeSpy = jest.fn(e => {
+            eventValue = e.target.checked;
+        });
+
+        const { getByLabelText, getByText } = render(
+            <Form
+                onSubmit={data => {
+                    submitData = data;
+                }}
+            >
+                {() => (
+                    <Form.CheckboxGroupController name="textCheck">
+                        {({ getCheckboxProps, getLabelProps }) => (
+                            <fieldset>
+                                <legend>Test check</legend>
+                                <div>
+                                    <input
+                                        {...getCheckboxProps({
+                                            name: 'one',
+                                            onChange: onChangeSpy
+                                        })}
+                                    />
+                                    <label
+                                        {...getLabelProps({
+                                            autoIdPostfix: 'one'
+                                        })}
+                                    >
+                                        One
+                                    </label>
+                                </div>
+                                <button type="submit">Submit</button>
+                            </fieldset>
+                        )}
+                    </Form.CheckboxGroupController>
+                )}
+            </Form>
+        );
+
+        fireEvent.click(getByLabelText('One'));
+        fireEvent.click(getByText('Submit'));
+
+        expect(submitData).toEqual({ textCheck: ['one'] });
+
+        expect(onChangeSpy).toHaveBeenCalled();
+        expect(eventValue).toBe(true);
+    });
+
     it('should spawn standard and ARIA props for a disabled checkbox', () => {
         const { getByLabelText } = render(
             <Form onSubmit={jest.fn()}>

--- a/src/modules/forms/tenonForm/__tests__/Form.RadioGroupController.spec.js
+++ b/src/modules/forms/tenonForm/__tests__/Form.RadioGroupController.spec.js
@@ -67,6 +67,59 @@ describe('Form.RadioGroupController', () => {
         expect(inputTwo.attributes.length).toBe(4);
     });
 
+    it('should run a custom onChange handler, when given', () => {
+        let eventValue = '';
+
+        let submitData = null;
+
+        const onChangeSpy = jest.fn(e => {
+            eventValue = e.target.value;
+        });
+
+        const { getByLabelText, getByText } = render(
+            <Form
+                onSubmit={data => {
+                    submitData = data;
+                }}
+            >
+                {() => (
+                    <Form.RadioGroupController name="testRadio">
+                        {({ getRadioButtonProps, getLabelProps }) => (
+                            <fieldset>
+                                <legend>Test check</legend>
+                                <div>
+                                    <input
+                                        {...getRadioButtonProps({
+                                            name: 'one',
+                                            value: 'one',
+                                            onChange: onChangeSpy
+                                        })}
+                                    />
+                                    <label
+                                        {...getLabelProps({
+                                            autoIdPostfix: 'one'
+                                        })}
+                                    >
+                                        One
+                                    </label>
+                                </div>
+                                <button type="submit">Submit</button>
+                            </fieldset>
+                        )}
+                    </Form.RadioGroupController>
+                )}
+            </Form>
+        );
+
+        fireEvent.click(getByLabelText('One'));
+        fireEvent.click(getByText('Submit'));
+
+        expect(submitData).toEqual({ testRadio: 'one' });
+
+        expect(onChangeSpy).toHaveBeenCalled();
+        expect(eventValue).toBe('one');
+    });
+
     it('should allow view injection via the component prop', () => {
         const RadioGroup = ({
             getRadioButtonProps,

--- a/src/modules/forms/tenonForm/__tests__/Form.SelectController.spec.js
+++ b/src/modules/forms/tenonForm/__tests__/Form.SelectController.spec.js
@@ -136,6 +136,57 @@ describe('Form.SelectController', () => {
         expect(testSelect.attributes.length).toBe(3);
     });
 
+    it('should run a custom onChange handler, when given', () => {
+        let eventValue = '';
+
+        const onChangeSpy = jest.fn(e => {
+            eventValue = e.target.value;
+        });
+
+        const { getByLabelText, getByTestId } = render(
+            <Form onSubmit={jest.fn()}>
+                {({ formControls }) => (
+                    <div>
+                        <span data-testid="resultContainer">
+                            {formControls.testSelect
+                                ? formControls.testSelect.value
+                                : ''}
+                        </span>
+                        <Form.SelectController name="testSelect">
+                            {({ getSelectProps, getLabelProps }) => {
+                                return (
+                                    <div>
+                                        <label {...getLabelProps()}>
+                                            Test select
+                                        </label>
+                                        <select
+                                            {...getSelectProps({
+                                                onChange: onChangeSpy
+                                            })}
+                                        >
+                                            <option value="one">1</option>
+                                            <option value="two">2</option>
+                                        </select>
+                                    </div>
+                                );
+                            }}
+                        </Form.SelectController>
+                        <button type="submit">Submit</button>
+                    </div>
+                )}
+            </Form>
+        );
+
+        const select = getByLabelText('Test select');
+
+        select.value = 'two';
+        fireEvent.change(select);
+
+        expect(getByTestId('resultContainer')).toHaveTextContent('two');
+        expect(onChangeSpy).toHaveBeenCalled();
+        expect(eventValue).toBe('two');
+    });
+
     it('should validate a select and set an error text when appropriate', () => {
         const { getByLabelText, getByTestId, getByText } = render(
             <Form onSubmit={jest.fn()}>

--- a/src/modules/forms/tenonForm/__tests__/Form.TextInputController.spec.js
+++ b/src/modules/forms/tenonForm/__tests__/Form.TextInputController.spec.js
@@ -181,6 +181,54 @@ describe('Form.TextInputController', () => {
         expect(testInput.attributes.length).toBe(5);
     });
 
+    it('should run a custom onChange handler, when given', () => {
+        let eventValue = '';
+
+        const onChangeSpy = jest.fn(e => {
+            eventValue = e.target.value;
+        });
+
+        const { getByLabelText, getByTestId } = render(
+            <Form onSubmit={jest.fn()}>
+                {({ formControls }) => (
+                    <div>
+                        <span data-testid="resultContainer">
+                            {formControls.testInput
+                                ? formControls.testInput.value
+                                : ''}
+                        </span>
+                        <Form.TextInputController name="testInput">
+                            {({ getInputProps, getLabelProps }) => {
+                                return (
+                                    <div>
+                                        <label {...getLabelProps()}>
+                                            Test input
+                                        </label>
+                                        <input
+                                            {...getInputProps({
+                                                onChange: onChangeSpy
+                                            })}
+                                        />
+                                    </div>
+                                );
+                            }}
+                        </Form.TextInputController>
+                        <button type="submit">Submit</button>
+                    </div>
+                )}
+            </Form>
+        );
+
+        const input = getByLabelText('Test input');
+
+        input.value = 'Some text';
+        fireEvent.change(input);
+
+        expect(getByTestId('resultContainer')).toHaveTextContent('Some text');
+        expect(onChangeSpy).toHaveBeenCalled();
+        expect(eventValue).toBe('Some text');
+    });
+
     it('should validate an input and set an error text when appropriate', () => {
         const { getByLabelText, getByTestId, getByText } = render(
             <Form onSubmit={jest.fn()}>

--- a/src/modules/forms/tenonForm/__tests__/Form.TextareaController.spec.js
+++ b/src/modules/forms/tenonForm/__tests__/Form.TextareaController.spec.js
@@ -161,6 +161,54 @@ describe('Form.TextareaController', () => {
         expect(testTextarea.attributes.length).toBe(4);
     });
 
+    it('should run a custom onChange handler, when given', () => {
+        let eventValue = '';
+
+        const onChangeSpy = jest.fn(e => {
+            eventValue = e.target.value;
+        });
+
+        const { getByLabelText, getByTestId } = render(
+            <Form onSubmit={jest.fn()}>
+                {({ formControls }) => (
+                    <div>
+                        <span data-testid="resultContainer">
+                            {formControls.testTextarea
+                                ? formControls.testTextarea.value
+                                : ''}
+                        </span>
+                        <Form.TextareaController name="testTextarea">
+                            {({ getTextareaProps, getLabelProps }) => {
+                                return (
+                                    <div>
+                                        <label {...getLabelProps()}>
+                                            Test textarea
+                                        </label>
+                                        <textarea
+                                            {...getTextareaProps({
+                                                onChange: onChangeSpy
+                                            })}
+                                        />
+                                    </div>
+                                );
+                            }}
+                        </Form.TextareaController>
+                        <button type="submit">Submit</button>
+                    </div>
+                )}
+            </Form>
+        );
+
+        const textarea = getByLabelText('Test textarea');
+
+        textarea.value = 'Some text';
+        fireEvent.change(textarea);
+
+        expect(getByTestId('resultContainer')).toHaveTextContent('Some text');
+        expect(onChangeSpy).toHaveBeenCalled();
+        expect(eventValue).toBe('Some text');
+    });
+
     it('should validate a textarea and set an error text when appropriate', () => {
         const { getByLabelText, getByTestId, getByText } = render(
             <Form onSubmit={jest.fn()}>

--- a/src/modules/tabs/Tabs.js
+++ b/src/modules/tabs/Tabs.js
@@ -238,17 +238,16 @@ class Tabs extends Component {
         this.tabRefs = {};
         this.panelRefs = {};
 
-        const tabPanelMetadata = tabChildren.map(
-            child =>
-                child.title
-                    ? {
-                          title: child.title,
-                          name: child.name,
-                          toggleRender: child.toggleRender,
-                          tabId: uuidv4(),
-                          panelId: uuidv4()
-                      }
-                    : {}
+        const tabPanelMetadata = tabChildren.map(child =>
+            child.title
+                ? {
+                      title: child.title,
+                      name: child.name,
+                      toggleRender: child.toggleRender,
+                      tabId: uuidv4(),
+                      panelId: uuidv4()
+                  }
+                : {}
         );
 
         const tabMetadata = tabPanelMetadata.filter(tab => !!tab.tabId);
@@ -307,8 +306,8 @@ class Tabs extends Component {
                     child && child.props.toggleRender
                         ? child.props.toggleRender
                         : toggleRender
-                            ? toggleRender
-                            : null
+                        ? toggleRender
+                        : null
             }))
         );
 

--- a/www/package.json
+++ b/www/package.json
@@ -5,10 +5,10 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@mdx-js/mdx": "^0.15.5",
-        "@mdx-js/tag": "^0.15.0",
+        "@mdx-js/mdx": "^0.16.0",
+        "@mdx-js/tag": "^0.16.0",
         "@reach/router": "^1.2.1",
-        "@tenon-io/tenon-codeblock": "^1.0.0-RC.2",
+        "@tenon-io/tenon-codeblock": "^1.0.0",
         "gatsby": "^2.0.31",
         "gatsby-mdx": "^0.2.0",
         "gatsby-plugin-manifest": "^2.0.5",

--- a/www/src/components/Disclosure.js
+++ b/www/src/components/Disclosure.js
@@ -36,8 +36,8 @@ const Target = ({ children, useHidden, deactivate }) => (
                       })
                   )
                 : expanded || deactivate
-                    ? children
-                    : null
+                ? children
+                : null
         }
     </DisclosureContext.Consumer>
 );

--- a/www/src/pages/code-block.mdx
+++ b/www/src/pages/code-block.mdx
@@ -1,23 +1,25 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Code block</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Code block</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Code block
 
-As developers we make applications for people, and as developers are people too sometimes we 
-build technical applications. 
+As developers we make applications for people, and as developers are people too sometimes we
+build technical applications.
 
 Sharing code should also be for everyone and the `Tenon-UI CodeBlock` helps you achieve that by
 giving you an easy to use accessible highlighted code block.
 
-This component leverages [react-syntax-highlighter](https://github.com/conorhastings/react-syntax-highlighter). 
+This component leverages [react-syntax-highlighter](https://github.com/conorhastings/react-syntax-highlighter).
 However some tweaks have been made to ensure that all text has sufficient colour contrast to be readable by as many
 people as possible.
 
@@ -26,7 +28,7 @@ people as possible.
 ### Installation
 
 Due to the payload size of a syntax highlighting, this component is not part of the main
-`Tenon-UI` package. 
+`Tenon-UI` package.
 
 #### Installing with npm
 
@@ -42,13 +44,13 @@ yarn add @tenon-io/tenon-codeblock
 
 ### Usage
 
-The code block can either display the contents of a file or a code string, making it highly 
+The code block can either display the contents of a file or a code string, making it highly
 flexible.
 
 #### With a file
 
 ```
-//... 
+//...
 
 import CodeBlock from '@tenon-io/tenon-codeblock';
 
@@ -68,7 +70,7 @@ real time.
 #### With a code string
 
 ```
-//... 
+//...
 
 import CodeBlock from '@tenon-io/tenon-codeblock';
 
@@ -98,12 +100,15 @@ code block is reset when the code block loses focus.
 ### Component props
 
 #### file
+
 The url of the code file you would like to display in the code block.
 
 #### codeString
+
 A formatted code string you would like to display in the code block.
 
 #### onReset
+
 An event handler that gets called if the user changes the code and the code is subsequently
 reset `onBlur`.
 
@@ -121,7 +126,8 @@ With this event you could inform your users that the text has been reset for the
 ```
 
 #### language
-In order to keep the bundle size small, the most common languages supported in a React 
+
+In order to keep the bundle size small, the most common languages supported in a React
 application are supported:
 
 1. **jsx**
@@ -141,10 +147,3 @@ By default the code block is setup to render `JSX` code but you can specify the 
 ```
 
 If you would like to use this code block with another language format, please let us know!
-
- 
-
-
-
-
-

--- a/www/src/pages/focus-catcher.mdx
+++ b/www/src/pages/focus-catcher.mdx
@@ -1,14 +1,16 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import FocusCatcher from '../../../src/modules/utils/components/FocusCatcher';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Focus catcher</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Focus catcher</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Focus catcher
 
@@ -16,11 +18,11 @@ Usually the `React event system` fully respects and follows the way events work 
 `browser DOM`.
 
 But with `focus` and `blur` this is different. In React, both of these events are bubbled up the
-tree until they are handled. This is a conscious decision, and even makes it possible to 
+tree until they are handled. This is a conscious decision, and even makes it possible to
 [sanely implement alternatives for Focus Outside](https://reactjs.org/docs/accessibility.html#mouse-and-pointer-events).
 
 In accessible applications you want to keep the CSS focus outline intact for all elements that can
-receive focus. But here this bubbling can cause some unexpected side effects. 
+receive focus. But here this bubbling can cause some unexpected side effects.
 
 The input below sits in a focusable container: a `div` that has been given `tabIndex="-1"` because
 we may want to set focus to it later via code. Click on the label below to see the side effect:
@@ -71,5 +73,3 @@ Here is the same example as above, but with the `FocusCatcher` component introdu
         </div>
     </FocusCatcher>
 </div>
-
-

--- a/www/src/pages/forms-create-your-own-checkbox-view.mdx
+++ b/www/src/pages/forms-create-your-own-checkbox-view.mdx
@@ -1,66 +1,80 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import PageNav from '../components/PageNav';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Create your own Checkbox view</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Create your own Checkbox view</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Create your own Checkbox view
 
-<PageNav targets={
-    ['Available prop getters from CheckboxController',
-    'Other props from CheckboxController', 
-    'Basic non-validated checkbox',
-    'Required validated checkbox',
-    'Checkbox with a content hint']
-    } />
+<PageNav
+    targets={[
+        'Available prop getters from CheckboxController',
+        'Other props from CheckboxController',
+        'Basic non-validated checkbox',
+        'Required validated checkbox',
+        'Checkbox with a content hint'
+    ]}
+/>
 
-Here you will see how to create your own `Checkbox` view. When creating your own view inline, 
+Here you will see how to create your own `Checkbox` view. When creating your own view inline,
 you will use the `children render prop` of the `CheckboxController`.
 
 ### Available prop getters from CheckboxController
+
 The `CheckboxController` gives you access to the following prop getter functions:
 
 #### getLabelProps
+
 This prop getter generates the required props for the `<label>` element.
 
 #### getCheckboxProps
+
 This prop getter generates the required props for the `<input>` element.
 
 #### getErrorProps
+
 This prop getter generates the required props for the container element of your
 displayed errors.
 
 #### getContentHintProps
+
 This prop getter generates the required props for the container element of your
 content hint text.
 
 ### Other props from CheckboxController
-A number of other props are also exposed by the `CheckboxController`. Refer to the 
+
+A number of other props are also exposed by the `CheckboxController`. Refer to the
 [smart controllers page](/forms-smart-controllers) to see how validators work:
 
 #### showError
+
 This boolean value will indicate to the view if an error should be shown. Normally, errors
 will only be shown after the first submit attempt unless overridden by the `alwaysShowErrors`
 prop of the [Form component](/forms-form-component).
 
-Use this to easily hide and show your error containers. 
+Use this to easily hide and show your error containers.
 
 #### errorText
+
 This value contains the current actual error message text. For valid or non-validated fields
-this will be empty. Otherwise if will contain the text from the first failing validator as 
-specified on the `CheckboxController`. 
+this will be empty. Otherwise if will contain the text from the first failing validator as
+specified on the `CheckboxController`.
 
 #### required
+
 This boolean value indicates if the `CheckboxController` has been marked as `required`. This
 can be handy to decide when to render required indicators.
 
 ### Basic non-validated checkbox
+
 If you only need a label and a checkbox you can write view code resembling this:
 
 ```
@@ -84,8 +98,8 @@ import { Form } from '@tenon-io/tenon-ui';
 
 Here the label follows the `<input>`. This is common practise when rendering checkboxes.
 
-**Note**: that both the `getLabelProps` and the `getCheckboxProps` prop getters can be called 
-with an object that can override and / or enrich the props object returned by these prop getters. 
+**Note**: that both the `getLabelProps` and the `getCheckboxProps` prop getters can be called
+with an object that can override and / or enrich the props object returned by these prop getters.
 For example:
 
 ```
@@ -97,6 +111,7 @@ For example:
 ```
 
 ### Required validated checkbox
+
 For validation, you can make use of the `getErrorProps` prop getter as well.
 
 ```
@@ -108,7 +123,7 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
     name="acceptConditions"
     validators={[
         validator(
-        value => value === true, 
+        value => value === true,
         'Please indicate that your accept the terms and conditions.'
         )
     ]}
@@ -149,14 +164,15 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
 ```
 
 Note in the example above that the visual `( required )` text is marked with `aria-hidden="true"`. This
-is because the `CheckboxController` already marks the input as `required` with the 
+is because the `CheckboxController` already marks the input as `required` with the
 `aria-required` property. Therefore you need to make sure that this is not read out twice by
 screen readers.
 
 The prop getters will ensure that the error text field is linked to the input and that the input
-validity (`aria-valid`) is managed and read out by screen readers. 
+validity (`aria-valid`) is managed and read out by screen readers.
 
 ### Checkbox with a content hint
+
 Should you want to render a `content hint`, please make use of the `getContentHintProps` prop getter:
 
 ```
@@ -168,7 +184,7 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
     name="acceptConditions"
     validators={[
         validator(
-        value => value === true, 
+        value => value === true,
         'Please indicate that your accept the terms and conditions.'
         )
     ]}
@@ -220,7 +236,4 @@ The prop getter will ensure that the `content hint` is also linked to the `<inpu
 screen readers are aware of this.
 
 As shown above you can easily combine this with an error field, although a content hint can safely be
-rendered on its own. 
-
-
-
+rendered on its own.

--- a/www/src/pages/forms-create-your-own-checkboxgroup-radiogroup-view.mdx
+++ b/www/src/pages/forms-create-your-own-checkboxgroup-radiogroup-view.mdx
@@ -1,55 +1,63 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import PageNav from '../components/PageNav';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Create your own CheckboxGroup or RadioGroup view</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>
+                Tenon-ui | Create your own CheckboxGroup or RadioGroup view
+            </title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Create your own CheckboxGroup or RadioGroup view
 
-<PageNav targets={
-    ['Checkbox and radiobutton groups',
-    'Available prop getters from CheckboxGroupController',
-    'Available prop getters from RadioGroupController',
-    'Other props', 
-    'Basic non-validated checkbox and radiobutton group',
-    'Required validated checkbox and radiobutton group',
-    'Checkbox and radiobutton group with a content hint']
-    } />
+<PageNav
+    targets={[
+        'Checkbox and radiobutton groups',
+        'Available prop getters from CheckboxGroupController',
+        'Available prop getters from RadioGroupController',
+        'Other props',
+        'Basic non-validated checkbox and radiobutton group',
+        'Required validated checkbox and radiobutton group',
+        'Checkbox and radiobutton group with a content hint'
+    ]}
+/>
 
-Here you will see how to create your own `CheckboxGroup` and `RadioGroup` view. When creating your own view inline, 
-you will use the `children render prop` of either the `CheckboxGroupController` or the 
+Here you will see how to create your own `CheckboxGroup` and `RadioGroup` view. When creating your own view inline,
+you will use the `children render prop` of either the `CheckboxGroupController` or the
 `RadioGroupController`.
 
 Creating these views are so similar they will be discussed on this one page with the small differences highlighted.
 
 ### Checkbox and radiobutton groups
-Making these groups accessible is surprisingly tricky, despite their prolific use. Please reconsider 
+
+Making these groups accessible is surprisingly tricky, despite their prolific use. Please reconsider
 using the `CheckboxGroup` and `RadioGroup` components provided.
 
 If you still want to build your own view, please take into account the following:
 
 1. Groups of elements should go inside a `<fieldset>` element and be described by a `<legend>`.
 1. In order for most screen readers out there to recognise the `<legend>`, it **HAS** to be
-the very next element after the `<fieldset>` opens. Please do not put any other HTML between the 
-opening tag of the `<fieldset>` and the `<legend>`.
-1. Unlike controls such as the `<input>`, there is no reliable way to connect `error messages` or 
-`content hints` to a `<fieldset>`. These messages must therefore be rendered into the `<legend>` 
-element. Should this text not need be visible, it can be hidden with a style that visually hides
-content.
+   the very next element after the `<fieldset>` opens. Please do not put any other HTML between the
+   opening tag of the `<fieldset>` and the `<legend>`.
+1. Unlike controls such as the `<input>`, there is no reliable way to connect `error messages` or
+   `content hints` to a `<fieldset>`. These messages must therefore be rendered into the `<legend>`
+   element. Should this text not need be visible, it can be hidden with a style that visually hides
+   content.
 1. When setting focus to this group, focus should land on the first `<input type="checkbox">` or
-`<input type="radio">` of the group.
+   `<input type="radio">` of the group.
 
 The `CheckboxGroupController` and `RadioGroupController` does a lot to support you in this, but if your view does not support
 the points mentioned above, your resulting group of elements will be almost certainly
 inaccessible.
 
 The visually hidden style mentioned above can be created like this:
+
 ```css
 .visually-hidden {
     position: absolute !important;
@@ -66,44 +74,55 @@ Therefore we will once again urge you to use the `CheckboxGroup` and `RadioGroup
 Still not convinced? Then keep these points in mind in the following sections.
 
 ### Available prop getters from CheckboxGroupController
+
 The `CheckboxGroupController` gives you access to the following prop getter functions:
 
 #### getLabelProps
+
 This prop getter generates the required props for each checkbox's `<label>` element.
 
 #### getCheckboxProps
+
 This prop getter generates the required props for the `<input>` elements of each checkbox.
 
 ### Available prop getters from RadioGroupController
+
 The `RadioGroupController` gives you access to the following prop getter functions:
 
 #### getLabelProps
+
 This prop getter generates the required props for each checkbox's `<label>` element.
 
 #### getRadioButtonProps
+
 This prop getter generates the required props for the `<input>` elements of each radiobutton.
 
 ### Other props
-A number of other props are also exposed by the `CheckboxGroupController` and `RadioGroupController. Refer to the 
+
+A number of other props are also exposed by the `CheckboxGroupController` and `RadioGroupController. Refer to the
 [smart controllers page](/forms-smart-controllers) to see how validators work:
 
 #### showError
+
 This boolean value will indicate to the view whether an error should be shown. Normally, errors
 will only be shown after the first submit attempt unless overridden by the `alwaysShowErrors`
 prop of the [Form component](/forms-form-component).
 
-Use this to easily hide and show your error containers. 
+Use this to easily hide and show your error containers.
 
 #### errorText
+
 This value contains the current actual error message text. For valid or non-validated fields
-this will be empty. Otherwise if will contain the text from the first failing validator as 
-specified on the controller. 
+this will be empty. Otherwise if will contain the text from the first failing validator as
+specified on the controller.
 
 #### required
+
 This boolean value indicates if the controller has been marked as `required`. This
 can be handy to decide when to render required indicators.
 
 ### Basic non-validated checkbox and radiobutton group
+
 If you only need a group of checkboxes without validation you can write view code resembling this:
 
 ```
@@ -210,11 +229,11 @@ import { Form } from '@tenon-io/tenon-ui';
 </Form.RadioGroupController>
 ```
 
-Here you will notice something strange going on. As you will see in the documentation for the 
-`ErrorBlock` component, we sometimes need to link to our form controls when they are in error. 
+Here you will notice something strange going on. As you will see in the documentation for the
+`ErrorBlock` component, we sometimes need to link to our form controls when they are in error.
 
-For single elements, this is easy, but for a group of checkboxes or radiobuttons we want to link to and 
-set focus on the element of the set. 
+For single elements, this is easy, but for a group of checkboxes or radiobuttons we want to link to and
+set focus on the element of the set.
 
 The controllers do not reliably know which of the child elements in their render
 props are the first. And neither should they try to figure this out as this would lead to more
@@ -223,7 +242,7 @@ tightly coupled code. So we need to do some further configuration in our views.
 Firstly we need to tell the controllers which element is intended to receive focus in an error
 condition. We do this with the `focusElement` configuration setting.
 
-For checkbox groups we do this by passing `focusElement: true` into the config object of the 
+For checkbox groups we do this by passing `focusElement: true` into the config object of the
 `getCheckboxProps` prop getter for the first checkbox:
 
 ```
@@ -250,12 +269,12 @@ For radiobutton groups we do this by passing `focusElement: true` into the confi
 />
 ```
 
-And for each radiobutton you need to pass in the `value`. The selected radiobutton will assign its 
+And for each radiobutton you need to pass in the `value`. The selected radiobutton will assign its
 `value` as the value of the entire control.
 
 `Tenon-ui` also automatically generates element `id` attributes for you. For checkbox groups, the
 `CheckboxGroupController` will use the `name` values to keep the different checkbox id values
-unique. Similarly the `RadioGroupController` will use the `value` values. 
+unique. Similarly the `RadioGroupController` will use the `value` values.
 
 Have a look at this `HTML` snippet of a checkbox group rendered with `Tenon-UI` to illustrate the effect
 of this (due to the similarity of the radiobuttons group only the checkbox group will be shown):
@@ -264,19 +283,21 @@ of this (due to the similarity of the radiobuttons group only the checkbox group
 <ul class="checkbox-container">
     <li>
         <div class="checkbox-wrapper">
-            <input name="morning" 
-                   id="16a32b1a-746e-4b96-ac53-88d85bdad598"
-                   type="checkbox">
-            <label for="16a32b1a-746e-4b96-ac53-88d85bdad598">
-                Morning
-            </label>
+            <input
+                name="morning"
+                id="16a32b1a-746e-4b96-ac53-88d85bdad598"
+                type="checkbox"
+            />
+            <label for="16a32b1a-746e-4b96-ac53-88d85bdad598"> Morning </label>
         </div>
     </li>
     <li>
         <div class="checkbox-wrapper">
-            <input name="noon" 
-                   id="16a32b1a-746e-4b96-ac53-88d85bdad598-noon" 
-                   type="checkbox">
+            <input
+                name="noon"
+                id="16a32b1a-746e-4b96-ac53-88d85bdad598-noon"
+                type="checkbox"
+            />
             <label for="16a32b1a-746e-4b96-ac53-88d85bdad598-noon">
                 Noon
             </label>
@@ -284,16 +305,18 @@ of this (due to the similarity of the radiobuttons group only the checkbox group
     </li>
     <li>
         <div class="checkbox-wrapper">
-            <input name="night" 
-                   id="16a32b1a-746e-4b96-ac53-88d85bdad598-night"
-                   type="checkbox">
+            <input
+                name="night"
+                id="16a32b1a-746e-4b96-ac53-88d85bdad598-night"
+                type="checkbox"
+            />
             <label for="16a32b1a-746e-4b96-ac53-88d85bdad598-night">
                 Night
             </label>
         </div>
     </li>
 </ul>
-``` 
+```
 
 Have a look at the `id` attributes. The first checkbox, which was marked as the `focusElement`,
 receives the unique `id` value generated for the group element.
@@ -313,7 +336,7 @@ to pass in an `autoIdPostfix` configuration object value to the `getLabelProps` 
 >
 ```
 
-This can, of course, also be automated in a `map`, as we see in the source code for the 
+This can, of course, also be automated in a `map`, as we see in the source code for the
 `CheckboxGroup` component:
 
 ```
@@ -344,7 +367,7 @@ You may also notice that in our examples, the checkboxes are rendered inside a `
 also do that for the radiobutton.
 
 This is done to give further assistance to screen reader users as they will then get to hear
-how many elements are inside the current group. Decide for yourself if you also want to 
+how many elements are inside the current group. Decide for yourself if you also want to
 add this extra bit of assistance.
 
 We realise that this is not very intuitive, but we have spent a lot of time to come up with a
@@ -356,7 +379,7 @@ In this case we are limited by how these elements are interpreted by assistive t
 
 ### Required validated checkbox and radiobutton group
 
-Render your error messages directly into the `<legend>` element. You can move these containers with 
+Render your error messages directly into the `<legend>` element. You can move these containers with
 styling.
 
 Or you can hide it with a `visually-hidden` style and render the visible message further down and
@@ -364,28 +387,27 @@ hide that from screen readers with `aria-hidden="true"`.
 
 Note that the `required` text is also rendered into the `<legend>`.
 
-
 For checkboxes:
 
 ```
 import { Form } from '@tenon-io/tenon-ui';
- 
+
 //...
- 
-<Form.CheckboxGroupController  
+
+<Form.CheckboxGroupController
    required="true"
    validators={[
        validator(
            value => value.length > 0,
            'Please select at least one eating time.'
        )
-   ]} 
+   ]}
    name="eatingTimes">
-    {({ getLabelProps, 
+    {({ getLabelProps,
         getCheckboxProps,
-        required, 
-        errorText, 
-        showError 
+        required,
+        errorText,
+        showError
     }) => (
         <fieldset>
             <legend>
@@ -450,28 +472,28 @@ import { Form } from '@tenon-io/tenon-ui';
     )}
 </Form.CheckboxGroupController>
 ```
- 
+
 Similarly, for radiobuttons:
- 
+
 ```
 import { Form } from '@tenon-io/tenon-ui';
- 
+
 //...
- 
-<Form.RadioGroupController 
+
+<Form.RadioGroupController
     required="true"
     validators={[
         validator(
             isRequired,
             'Please select a colour for your pet.'
         )
-    ]} 
+    ]}
     name="petColour">
-    {({ getLabelProps, 
+    {({ getLabelProps,
         getRadioButtonProps,
-        required, 
-        errorText, 
-        showError 
+        required,
+        errorText,
+        showError
     }) => (
         <fieldset>
             <legend>
@@ -539,147 +561,141 @@ import { Form } from '@tenon-io/tenon-ui';
 
 ### Checkbox and radiobutton group with a content hint
 
-We add a `content hint` in the same way, although for these elements we do not get any 
+We add a `content hint` in the same way, although for these elements we do not get any
 assistance from the controllers.
 
- ```
+```
 import { Form } from '@tenon-io/tenon-ui';
- 
+
 //...
- 
-<Form.CheckboxGroupController  
-   name="eatingTimes">
-    {({ getLabelProps, 
-        getCheckboxProps
-    }) => (
-        <fieldset>
-            <legend>
-                When does your pet eat?
-                {contentHintText && (
-                    <span className="visually-hidden">
-                        &nbsp;
-                        Remember 12 o'clock means noon!
-                    </span>
-                )}
+
+<Form.CheckboxGroupController
+  name="eatingTimes">
+   {({ getLabelProps,
+       getCheckboxProps
+   }) => (
+       <fieldset>
+           <legend>
+               When does your pet eat?
+               {contentHintText && (
+                   <span className="visually-hidden">
+                       &nbsp;
+                       Remember 12 o'clock means noon!
+                   </span>
+               )}
+           </legend>
+           <input
+               {...getCheckboxProps({
+                   name: 'morning',
+                   focusElement: true
+               })}
+           />
+           <label
+               {...getLabelProps()}
+           >
+               In the morning
+           </label>
+           <input
+               {...getCheckboxProps({
+                   name: 'noon'
+               })}
+           />
+           <label
+               {...getLabelProps({
+                   autoIdPostfix: 'noon'
+               })}
+           >
+               At noon
+           </label>
+           <input
+               {...getCheckboxProps({
+                   name: 'night'
+               })}
+           />
+           <label
+               {...getLabelProps({
+                   autoIdPostfix: 'night'
+               })}
+           >
+               At night
+           </label>
+           {contentHintText && (
+               <div className="content-hint-style"
+                    aria-hidden="true"
+               >
+                   Remember 12 o'clock means noon!
+               </div>
+           )}
+       </fieldset>
+   )}
+</Form.CheckboxGroupController>
+```
+
+Similarly, for radiobuttons:
+
+```
+import { Form } from '@tenon-io/tenon-ui';
+
+//...
+
+<Form.RadioGroupController
+   name="petColour">
+   {({ getLabelProps,
+       getRadioButtonProps
+   }) => (
+       <fieldset>
+           <legend>
+               What colour is your pet?
+               {contentHintText && (
+                   <span className="visually-hidden">
+                       &nbsp;
+                       Choose the predominant colour.
+                   </span>
+               )}
             </legend>
             <input
-                {...getCheckboxProps({
-                    name: 'morning',
+                {...getRadioButtonProps({
+                    value: 'black',
                     focusElement: true
                 })}
             />
             <label
                 {...getLabelProps()}
             >
-                In the morning
+                Black
             </label>
             <input
-                {...getCheckboxProps({
-                    name: 'noon'
+                {...getRadioButtonProps({
+                    value: 'brown'
                 })}
             />
             <label
                 {...getLabelProps({
-                    autoIdPostfix: 'noon'
+                    autoIdPostfix: 'brown'
                 })}
             >
                 At noon
             </label>
             <input
-                {...getCheckboxProps({
-                    name: 'night'
+                {...getRadioButtonProps({
+                    value: 'white'
                 })}
             />
             <label
                 {...getLabelProps({
-                    autoIdPostfix: 'night'
+                    autoIdPostfix: 'white'
                 })}
             >
                 At night
             </label>
-            {contentHintText && (
-                <div className="content-hint-style"
-                     aria-hidden="true"
-                >
-                    Remember 12 o'clock means noon!
-                </div>
-            )}
+           {contentHintText && (
+               <div className="content-hint-style"
+                    aria-hidden="true"
+               >
+                    Choose the predominant colour.
+               </div>
+           )}
         </fieldset>
     )}
-</Form.CheckboxGroupController>
- ```
- 
-Similarly, for radiobuttons:
- 
- ```
-import { Form } from '@tenon-io/tenon-ui';
- 
-//...
- 
-<Form.RadioGroupController 
-    name="petColour">
-    {({ getLabelProps, 
-        getRadioButtonProps
-    }) => (
-        <fieldset>
-            <legend>
-                What colour is your pet?
-                {contentHintText && (
-                    <span className="visually-hidden">
-                        &nbsp;
-                        Choose the predominant colour.
-                    </span>
-                )}
-             </legend>
-             <input
-                 {...getRadioButtonProps({
-                     value: 'black',
-                     focusElement: true
-                 })}
-             />
-             <label
-                 {...getLabelProps()}
-             >
-                 Black
-             </label>
-             <input
-                 {...getRadioButtonProps({
-                     value: 'brown'
-                 })}
-             />
-             <label
-                 {...getLabelProps({
-                     autoIdPostfix: 'brown'
-                 })}
-             >
-                 At noon
-             </label>
-             <input
-                 {...getRadioButtonProps({
-                     value: 'white'
-                 })}
-             />
-             <label
-                 {...getLabelProps({
-                     autoIdPostfix: 'white'
-                 })}
-             >
-                 At night
-             </label>
-            {contentHintText && (
-                <div className="content-hint-style"
-                     aria-hidden="true"
-                >
-                     Choose the predominant colour.
-                </div>
-            )}
-         </fieldset>
-     )}
- </Form.RadioGroupController>
- ```
-
-
-   
-
-
-
+</Form.RadioGroupController>
+```

--- a/www/src/pages/forms-create-your-own-input-view.mdx
+++ b/www/src/pages/forms-create-your-own-input-view.mdx
@@ -1,66 +1,80 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import PageNav from '../components/PageNav';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Create your own Input view</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Create your own Input view</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Create your own Input view
 
-<PageNav targets={
-    ['Available prop getters from TextInputController',
-    'Other props from TextInputController', 
-    'Basic non-validated input',
-    'Required validated input',
-    'Input with a content hint']
-    } />
+<PageNav
+    targets={[
+        'Available prop getters from TextInputController',
+        'Other props from TextInputController',
+        'Basic non-validated input',
+        'Required validated input',
+        'Input with a content hint'
+    ]}
+/>
 
-Here you will see how to create your own `Input` view. When creating your own view inline, 
+Here you will see how to create your own `Input` view. When creating your own view inline,
 you will use the `children render prop` of the `TextInputController`.
 
 ### Available prop getters from TextInputController
+
 The `TextInputController` gives you access to the following prop getter functions:
 
 #### getLabelProps
+
 This prop getter generates the required props for the `<label>` element.
 
 #### getInputProps
+
 This prop getter generates the required props for the `<input>` element.
 
 #### getErrorProps
+
 This prop getter generates the required props for the container element of your
 displayed errors.
 
 #### getContentHintProps
+
 This prop getter generates the required props for the container element of your
 content hint text.
 
 ### Other props from TextInputController
-A number of other props are also exposed by the `TextInputController`. Refer to the 
+
+A number of other props are also exposed by the `TextInputController`. Refer to the
 [smart controllers page](/forms-smart-controllers) to see how validators work:
 
 #### showError
+
 This boolean value will indicate to the view if an error should be shown. Normally, errors
 will only be shown after the first submit attempt unless overridden by the `alwaysShowErrors`
 prop of the [Form component](/forms-form-component).
 
-Use this to easily hide and show your error containers. 
+Use this to easily hide and show your error containers.
 
 #### errorText
+
 This value contains the current actual error message text. For valid or non-validated fields
-this will be empty. Otherwise it will contain the text from the first failing validator as 
-specified on the `TextInputController`. 
+this will be empty. Otherwise it will contain the text from the first failing validator as
+specified on the `TextInputController`.
 
 #### required
+
 This boolean value indicates if the `TextInputController` has been marked as `required`. This
 can be handy to decide when to render required indicators.
 
 ### Basic non-validated input
+
 If you only need a label and an input you can write view code resembling this:
 
 ```
@@ -82,8 +96,8 @@ import { Form } from '@tenon-io/tenon-ui';
 </Form.TextInputController>
 ```
 
-**Note**: that both the `getLabelProps` and the `getInputProps` prop getters can be called 
-with an object that can override and / or enrich the props object returned by these prop getters. 
+**Note**: that both the `getLabelProps` and the `getInputProps` prop getters can be called
+with an object that can override and / or enrich the props object returned by these prop getters.
 For example:
 
 ```
@@ -96,6 +110,7 @@ For example:
 ```
 
 ### Required validated input
+
 For validation, you can use the `getErrorProps` prop getter as well.
 
 ```
@@ -145,14 +160,15 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
 ```
 
 Note in the example above that the visual `( required )` text is marked with `aria-hidden="true"`. This
-is because the `TextInputController` already marks the input as `required` with the 
+is because the `TextInputController` already marks the input as `required` with the
 `aria-required` property. Therefore you need to make sure that this is not read out twice by
 screen readers.
 
 The prop getters will ensure that the error text field is linked to the input and that the input
-validity (`aria-valid`) is managed and read out by screen readers. 
+validity (`aria-valid`) is managed and read out by screen readers.
 
 ### Input with a content hint
+
 Should you want to render a `content hint`, please make use of the `getContentHintProps` prop getter:
 
 ```
@@ -208,7 +224,4 @@ The prop getter will ensure that the `content hint` is also linked to the `<inpu
 screen readers are aware of this.
 
 As shown above you can easily combine this with an error field, although a content hint can safely be
-rendered on its own. 
-
-
-
+rendered on its own.

--- a/www/src/pages/forms-create-your-own-select-view.mdx
+++ b/www/src/pages/forms-create-your-own-select-view.mdx
@@ -1,66 +1,80 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import PageNav from '../components/PageNav';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Create your own Select view</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Create your own Select view</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Create your own Select view
 
-<PageNav targets={
-    ['Available prop getters from SelectController',
-    'Other props from SelectController', 
-    'Basic non-validated select',
-    'Required validated select',
-    'Select with a content hint']
-    } />
+<PageNav
+    targets={[
+        'Available prop getters from SelectController',
+        'Other props from SelectController',
+        'Basic non-validated select',
+        'Required validated select',
+        'Select with a content hint'
+    ]}
+/>
 
-Here you will see how to create your own `Select` view. When creating your own view inline, 
+Here you will see how to create your own `Select` view. When creating your own view inline,
 you will use the `children render prop` of the `SelectController`.
 
 ### Available prop getters from SelectController
+
 The `SelectController` gives you access to the following prop getter functions:
 
 #### getLabelProps
+
 This prop getter generates the required props for the `<label>` element.
 
 #### getSelect
+
 This prop getter generates the required props for the `<select>` element.
 
 #### getErrorProps
+
 This prop getter generates the required props for the container element of your
 displayed errors.
 
 #### getContentHintProps
+
 This prop getter generates the required props for the container element of your
 content hint text.
 
 ### Other props from SelectController
-A number of other props are also exposed by the `SelectController`. Refer to the 
+
+A number of other props are also exposed by the `SelectController`. Refer to the
 [smart controllers page](/forms-smart-controllers) to see how validators work:
 
 #### showError
+
 This boolean value will indicate to the view if an error should be shown. Normally, errors
 will only be shown after the first submit attempt unless overridden by the `alwaysShowErrors`
 prop of the [Form component](/forms-form-component).
 
-Use this to easily hide and show your error containers. 
+Use this to easily hide and show your error containers.
 
 #### errorText
+
 This value contains the current actual error message text. For valid or non-validated fields
-this will be empty. Otherwise if will contain the text from the first failing validator as 
-specified on the `SelectController`. 
+this will be empty. Otherwise if will contain the text from the first failing validator as
+specified on the `SelectController`.
 
 #### required
+
 This boolean value indicates if the `SelectController` has been marked as `required`. This
 can be handy to decide when to render required indicators.
 
 ### Basic non-validated select
+
 If you only need a label and a select you can write view code resembling this:
 
 ```
@@ -82,15 +96,15 @@ import { Form } from '@tenon-io/tenon-ui';
                 </option>
                 <option value="brown">
                     White
-                </option>        
+                </option>
             </select>
         </React.Fragment>
     )}
 </Form.SelectController>
 ```
 
-**Note**: that both the `getLabelProps` and the `getSelectProps` prop getters can be called 
-with an object that can override and / or enrich the props object returned by these prop getters. 
+**Note**: that both the `getLabelProps` and the `getSelectProps` prop getters can be called
+with an object that can override and / or enrich the props object returned by these prop getters.
 For example:
 
 ```
@@ -102,6 +116,7 @@ For example:
 ```
 
 ### Required validated select
+
 For validation, you can make use of the `getErrorProps` prop getter as well.
 
 ```
@@ -126,7 +141,7 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
     }) => (
         <React.Fragment>
             <label {...getLabelProps()}>
-                
+
                 {required && (
                     <span
                         aria-hidden="true"
@@ -143,7 +158,7 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
                 </option>
                 <option value="brown">
                     White
-                </option>        
+                </option>
             </select>
             {showError && (
                 <div
@@ -160,14 +175,15 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
 ```
 
 Note in the example above that the visual `( required )` text is marked with `aria-hidden="true"`. This
-is because the `SelectController` already marks the select as `required` with the 
+is because the `SelectController` already marks the select as `required` with the
 `aria-required` property. Therefore you need to make sure that this is not read out twice by
 screen readers.
 
 The prop getters will ensure that the error text field is linked to the select and that the select
-validity (`aria-valid`) is managed and read out by screen readers. 
+validity (`aria-valid`) is managed and read out by screen readers.
 
 ### Select with a content hint
+
 Should you want to render a `content hint`, please make use of the `getContentHintProps` prop getter:
 
 ```
@@ -202,7 +218,7 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
                 </option>
                 <option value="brown">
                     White
-                </option>        
+                </option>
             </select>
             <div
                 {...getContentHintProps({
@@ -229,7 +245,4 @@ The prop getter will ensure that the `content hint` is also linked to the `<sele
 screen readers are aware of this.
 
 As shown above you can easily combine this with an error field, although a content hint can safely be
-rendered on its own. 
-
-
-
+rendered on its own.

--- a/www/src/pages/forms-create-your-own-textarea-view.mdx
+++ b/www/src/pages/forms-create-your-own-textarea-view.mdx
@@ -1,66 +1,80 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import PageNav from '../components/PageNav';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Create your own Textarea view</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Create your own Textarea view</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Create your own Textarea view
 
-<PageNav targets={
-    ['Available prop getters from TextareaController',
-    'Other props from TextareaController', 
-    'Basic non-validated textarea',
-    'Required validated textarea',
-    'Textarea with a content hint']
-    } />
+<PageNav
+    targets={[
+        'Available prop getters from TextareaController',
+        'Other props from TextareaController',
+        'Basic non-validated textarea',
+        'Required validated textarea',
+        'Textarea with a content hint'
+    ]}
+/>
 
-Here you will see how to create your own `Textarea` view. When creating your own view inline, 
+Here you will see how to create your own `Textarea` view. When creating your own view inline,
 you will use the `children render prop` of the `TextareaController`.
 
 ### Available prop getters from TextareaController
+
 The `TextareaController` gives you access to the following prop getter functions:
 
 #### getLabelProps
+
 This prop getter generates the required props for the `<label>` element.
 
 #### getTextareaProps
+
 This prop getter generates the required props for the `<textarea>` element.
 
 #### getErrorProps
+
 This prop getter generates the required props for the container element of your
 displayed errors.
 
 #### getContentHintProps
+
 This prop getter generates the required props for the container element of your
 content hint text.
 
 ### Other props from TextareaController
-A number of other props are also exposed by the `TextareaController`. Refer to the 
+
+A number of other props are also exposed by the `TextareaController`. Refer to the
 [smart controllers page](/forms-smart-controllers) to see how validators work:
 
 #### showError
+
 This boolean value will indicate to the view if an error should be shown. Normally, errors
 will only be shown after the first submit attempt unless overridden by the `alwaysShowErrors`
 prop of the [Form component](/forms-form-component).
 
-Use this to easily hide and show your error containers. 
+Use this to easily hide and show your error containers.
 
 #### errorText
+
 This value contains the current actual error message text. For valid or non-validated fields
-this will be empty. Otherwise if will contain the text from the first failing validator as 
-specified on the `TextareaController`. 
+this will be empty. Otherwise if will contain the text from the first failing validator as
+specified on the `TextareaController`.
 
 #### required
+
 This boolean value indicates if the `TextareaController` has been marked as `required`. This
 can be handy to decide when to render required indicators.
 
 ### Basic non-validated textarea
+
 If you only need a label and a textarea you can write view code resembling this:
 
 ```
@@ -82,8 +96,8 @@ import { Form } from '@tenon-io/tenon-ui';
 </Form.TextareaController>
 ```
 
-**Note**: that both the `getLabelProps` and the `getTextareaProps` prop getters can be called 
-with an object that can override and / or amend the props object returned by these prop getters. 
+**Note**: that both the `getLabelProps` and the `getTextareaProps` prop getters can be called
+with an object that can override and / or amend the props object returned by these prop getters.
 For example:
 
 ```
@@ -96,6 +110,7 @@ For example:
 ```
 
 ### Required validated textarea
+
 For validation, you can make use of the `getErrorProps` prop getter as well.
 
 ```
@@ -145,14 +160,15 @@ import { Form, validator, isRequired } from '@tenon-io/tenon-ui';
 ```
 
 Note in the example above that the visual `( required )` text is marked with `aria-hidden="true"`. This
-is because the `TextareaController` already marks the textarea as `required` with the 
+is because the `TextareaController` already marks the textarea as `required` with the
 `aria-required` property. Therefore you need to make sure that this is not read out twice by
 screen readers.
 
 The prop getters will ensure that the error text field is linked to the textarea and that the textarea
-validity (`aria-valid`) is managed and read out by screen readers. 
+validity (`aria-valid`) is managed and read out by screen readers.
 
 ### Textarea with a content hint
+
 Should you want to render a `content hint`, please make use of the `getContentHintProps` prop getter:
 
 ```
@@ -207,7 +223,4 @@ The prop getter will ensure that the `content hint` is also linked to the `<text
 screen readers are aware of this.
 
 As shown above you can easily combine this with an error field, although a content hint can safely be
-rendered on its own. 
-
-
-
+rendered on its own.

--- a/www/src/pages/forms-error-block.mdx
+++ b/www/src/pages/forms-error-block.mdx
@@ -1,17 +1,19 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Put it all together with the ErrorBlock</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Put it all together with the ErrorBlock</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Put it all together with the ErrorBlock
 
-While we now know how to put forms together with the `Tenon-UI` components, we still need to 
+While we now know how to put forms together with the `Tenon-UI` components, we still need to
 put the cherry on the cake for validating complex forms.
 
 ### The ErrorBlock component
@@ -29,10 +31,10 @@ render function by the `Form` component:
 It also accepts a `headingText` prop that will be shown as the heading of the block.
 
 This will render a block of with a list of errors. Each error will be rendered as a functional
-link with a hash `href` to the form element that is in error. All of this is managed and handled 
+link with a hash `href` to the form element that is in error. All of this is managed and handled
 for you by `Tenon-UI`.
 
-By default the internal heading is rendered as an `<h2>` unless it is used inside the 
+By default the internal heading is rendered as an `<h2>` unless it is used inside the
 [Heading.LevelBoundary](/headings) component. You are also able to override this by using the
 `headingLevel` prop:
 
@@ -219,14 +221,14 @@ class DemoForm extends Component {
 export default DemoForm;
 ```
 
-You may have noticed one more thing you will need to do by hand. And that is set focus to the 
+You may have noticed one more thing you will need to do by hand. And that is set focus to the
 `ErrorBlock` when the user activates the submit button and there are validation errors.
 
 First we need to create a [React Ref](https://reactjs.org/docs/refs-and-the-dom.html).
 
 ```
 this.errorBlockRef = createRef();
-``` 
+```
 
 Then we attach it to the `ErrorBlock` component:
 
@@ -238,8 +240,8 @@ Then we attach it to the `ErrorBlock` component:
   />
 ```
 
-We can then use the `onRawSubmit` handler of the `Form` to set focus on error as this handler is 
-always called, not just when the form input is valid. 
+We can then use the `onRawSubmit` handler of the `Form` to set focus on error as this handler is
+always called, not just when the form input is valid.
 
 ```
 onRawSubmitHandler = (formControls, validity) => {
@@ -254,7 +256,7 @@ onRawSubmitHandler = (formControls, validity) => {
 The `validity` flag is the second parameter and we can then use that to determine whether or not
 to set focus.
 
-Unfortunately we need to use a `setTimeout`, as we need to be sure the `ErrorBlock` has been 
+Unfortunately we need to use a `setTimeout`, as we need to be sure the `ErrorBlock` has been
 applied to the `DOM` before setting focus.
 
 This is all the extra work you need to do as the `Form` component cannot handle this for you.

--- a/www/src/pages/forms-form-component.mdx
+++ b/www/src/pages/forms-form-component.mdx
@@ -1,15 +1,18 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | The Form component</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | The Form component</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## The Form component
+
 Instead of the standard JSX `<form>` element, use the `Form` component, imported from `Tenon.UI`.
 
 This component employs a [children render prop](https://reactjs.org/docs/render-props.html#using-props-other-than-render)
@@ -46,11 +49,13 @@ and will pass all the required data into the render function.
 ### Form props
 
 #### children
+
 This prop is required.
 
 A render function accepting three paramaters:
 
 ##### formControls
+
 A full summary object of all form controls on the page. This object is always up to date
 with the latest values from the form controls.
 
@@ -70,19 +75,22 @@ The structure of this object is:
 ```
 
 ##### validity
+
 A boolean value indicating the combined validity values for each form control. For `Form`s where
 all the controls pass validation the value will be `true`, if at least one control fails
 validation the value will be `false`.
 
 This flag can be used to trigger global error blocks, for example.
 
-##### hasSubmitted 
+##### hasSubmitted
+
 A boolean value indicating if the user has triggered an `onSubmit` event at least once.
 
 This can also be used to display information, such as error blocks, only after the user
 has attempted to submit the `Form`.
 
 #### onSubmit
+
 This prop is required.
 
 An event handler function that is called if a submit event occurs and all form controls
@@ -100,17 +108,20 @@ the current, valid values for each control on the `Form`, by control name:
     ..repeated for each control rendered on the form
 }
 ```
+
 #### onRawSubmit
+
 An optional event handler that gets triggered by every submit action on the `Form`, regardless
 of the validity state of the `Form`.
 
 This event handler gets called with a `formControls` and `validity` parameter that has the same
 shape and function of those injected into the view by the `Form`'s children render prop.
 
-This function can, for example, be used to set focus on a summary error block. 
+This function can, for example, be used to set focus on a summary error block.
 
-#### formData 
-An object used to pass data into the smart form, for instance when loading already saved data from 
+#### formData
+
+An object used to pass data into the smart form, for instance when loading already saved data from
 the server.
 
 This object shape mirrors that of the `submitData` object passed into the `onSubmit` handler.
@@ -127,11 +138,13 @@ the form. Every time this object is changed it will overwrite the form data. If 
 is changed via user interaction, these changes will **NOT** be reflected in this prop.
 
 #### alwaysShowErrors
+
 By default, the smart form control are built to only display validation error conditions once
 a submit has been attempted. As this is the user experience we recommend.
 
-Should the need arise to immediately show errors real-time, this boolean flag can be set to 
+Should the need arise to immediately show errors real-time, this boolean flag can be set to
 `true`.
 
 #### className
+
 Allows setting a `className` on the actual rendered `<form>` element.

--- a/www/src/pages/forms-knowledge.mdx
+++ b/www/src/pages/forms-knowledge.mdx
@@ -1,13 +1,15 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Smart form required knowledge</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Smart form required knowledge</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Smart form required knowledge
 
@@ -20,6 +22,7 @@ Using the standard `props.children` prop as a [render prop](https://reactjs.org/
 is used prolifically in the forms components.
 
 Example:
+
 ```
 import React from 'react';
 import { Form } from '@tenon-io/tenon-ui';
@@ -48,14 +51,14 @@ class FormClass extends React.Component {
 of the data and accessibility engine provided.
 
 Whereas we would like you to use our view components, as they will ensure accessibility
-of the components themselves, we also understand that UI component libraries are 
-often too restrictive and not every application and design you may need to code can be solved 
+of the components themselves, we also understand that UI component libraries are
+often too restrictive and not every application and design you may need to code can be solved
 with the same static views.
 
-`Tenon-ui` exposes its data and accessibility engine through `prop getter functions` injected 
+`Tenon-ui` exposes its data and accessibility engine through `prop getter functions` injected
 into render functions via `children render props`.
- 
-These functions allow you, not only to access the prop needed to drive your views, but also to 
+
+These functions allow you, not only to access the prop needed to drive your views, but also to
 override and enrich the standard set of props given:
 
 ```
@@ -78,5 +81,4 @@ override and enrich the standard set of props given:
 The specifics around the `Tenon-ui` components will be discussed later, but if the way
 this code snippet gives props to the `<label>` and `<input>` elements are not clear,
 please read this [blog post about prop getters](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf)
-by Kent C. Dodds. 
-
+by Kent C. Dodds.

--- a/www/src/pages/forms-smart-controllers.mdx
+++ b/www/src/pages/forms-smart-controllers.mdx
@@ -1,15 +1,18 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Smart form element controllers</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Smart form element controllers</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Smart form element controllers
+
 In the `Tenon-UI smart form` architecture, each control on your `Form` will talk to this parent `Form`
 automatically. Each control will also allow you to implement your own view.
 
@@ -18,21 +21,23 @@ each form control type has a `smart controller component`. These controller comp
 compound component.
 
 They are:
-- TextInputController
-- TextareaController
-- SelectController
-- CheckboxController
-- CheckboxGroupController
-- RadioGroupController
+
+-   TextInputController
+-   TextareaController
+-   SelectController
+-   CheckboxController
+-   CheckboxGroupController
+-   RadioGroupController
 
 Each of these controllers also accepts a `children render prop` function where any view can be injected.
 
 These controllers do the following for you:
-- Registers itself with the `Form` component and communicates all data and validation changes.
-- Provides all event handlers and data bindings required to turn your view controls into [controlled components](https://reactjs.org/docs/forms.html#controlled-components).
-- Auto calculates all `id` values required for your view in order ensure that id's remain unique.
-- Where possible, calculates accessibility states and properties required to make your view accessible.
-- Exposes all this information via [prop getter functions](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf).
+
+-   Registers itself with the `Form` component and communicates all data and validation changes.
+-   Provides all event handlers and data bindings required to turn your view controls into [controlled components](https://reactjs.org/docs/forms.html#controlled-components).
+-   Auto calculates all `id` values required for your view in order ensure that id's remain unique.
+-   Where possible, calculates accessibility states and properties required to make your view accessible.
+-   Exposes all this information via [prop getter functions](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf).
 
 Think of the controller components as where all the magic happens for each form control.
 
@@ -82,71 +87,77 @@ class FormClass extends React.Component {
     }
 }
 ```
+
 ### Controller props
+
 Each controller has access to the same three props, although the render function of each controller differs slightly.
 
 #### name
+
 This prop is required.
 
 Every controller must have a string name. This is the name with which it will register with the `Form` component. Subsequently,
 this is the name that will appear in the `Form` datasets mentioned above.
 
-#### component 
+#### component
+
 While the controllers have been built to easily inject any custom view, often you will extract that
 view to another component. And `Tenon-UI` also provides a number of view components for you.
- 
+
 Using these components in the render prop will lead the to following code being repeated:
- 
+
 ```
 {props => {
     return <SomeViewComponent {...props} />
 }}
 ```
- 
+
 To avoid this, you can use the `component` prop instead:
- ```
+
+```
 <Form.[Contoller]
-    name="petName"
-    component={SomeViewComponent}
-/>    
+   name="petName"
+   component={SomeViewComponent}
+/>
 ```
 
 Each controller will also pass any props not used in the controller itself through to the
 view component. This way you can still pass props, for instance a label text, to your
 view component.
 
-In this example, the `labelText` prop will be pass through to the `SomeViewComponent` 
+In this example, the `labelText` prop will be pass through to the `SomeViewComponent`
 view component:
- ```
+
+```
 <Form.[Contoller]
-    name="petName"
-    labelText="Pet name"
-    component={SomeViewComponent}
-/>    
+   name="petName"
+   labelText="Pet name"
+   component={SomeViewComponent}
+/>
 ```
 
 Finally, if the `component` prop is specified, the `children` of the controller component
 will be passed into the view component as its children. This can make it easier and more
 natural to create things like `<select>` boxes.
 
- ```
- //Inside SomeViewComponent
- <select {...getSelectProps()}>
-    {this.props.children}
- </select>
- 
-//Then it can be use as: 
+```
+//Inside SomeViewComponent
+<select {...getSelectProps()}>
+   {this.props.children}
+</select>
+
+//Then it can be use as:
 <Form.SelectController
-    name="petAge"
-    labelText="Pet age"
-    component={SomeViewComponent}
+   name="petAge"
+   labelText="Pet age"
+   component={SomeViewComponent}
 >
-    <option value="1">
-        One
-    </option>    
-    <option value="2">
-        Two
-    </option>
+   <option value="1">
+       One
+   </option>
+   <option value="2">
+       Two
+   </option>
 </Form.SelectController>
 ```
 
@@ -154,21 +165,24 @@ Whenever a component is used as view in the docs, we will prefer using the `comp
 over using the render prop.
 
 #### required
-A form control can be marked as required by activating this prop. This is important as it then passes important information 
+
+A form control can be marked as required by activating this prop. This is important as it then passes important information
 to the view components through the render function.
 
 The prop accepts both `boolean` as well as `string` values.
 
 #### validators
-This array of validators forms the heart of validation in `Tenon-UI`. 
+
+This array of validators forms the heart of validation in `Tenon-UI`.
 
 The library also exports a `validator` function you can use to compose the validators you add to the controllers. Each
 entry in the `validators` array should be composed with this function.
 
 The function takes three parameters:
 
-##### function 
-This is the validation function to run. 
+##### function
+
+This is the validation function to run.
 
 Validation functions should return `true` if the validation passes, and `false` if the validation fails.
 
@@ -176,7 +190,7 @@ You are free to create your own validation functions, it can even be done inline
 
 Validation functions come in two forms.
 
-The simple validation function accept a `value`, which will be injected into the function by the 
+The simple validation function accept a `value`, which will be injected into the function by the
 controller component. This `value` will be the current value of the control. And example of such a function
 is:
 
@@ -191,11 +205,11 @@ const isLongerThan = minLength => value =>
     !value || value.length > minLength;
 ```
 
-Note that these functions are `curried functions`. In the example shown above for the controller usage, it 
+Note that these functions are `curried functions`. In the example shown above for the controller usage, it
 can be seen how each one of these types of functions are used in the validators array.
 
 This second type of function can be used to create powerful validators between various form controls by
-injecting the value of another control from `formControls` render function object into the validator of 
+injecting the value of another control from `formControls` render function object into the validator of
 your control:
 
 ```
@@ -241,7 +255,7 @@ be shown, thereby freeing the view from more decision making logic.
 ##### ignore
 
 Sometimes you would like to turn off a specific validation programmatically. This third (optional)
-parameter allows you to ignore any specific validator. 
+parameter allows you to ignore any specific validator.
 
 To ignore a validator do:
 
@@ -252,4 +266,3 @@ validator(
     true
 )
 ```
-

--- a/www/src/pages/forms-view-components.mdx
+++ b/www/src/pages/forms-view-components.mdx
@@ -1,4 +1,4 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import PageNav from '../components/PageNav';
@@ -9,34 +9,42 @@ import Select from '../../../src/modules/forms/tenonForm/Select';
 import Checkbox from '../../../src/modules/forms/tenonForm/Checkbox';
 import CheckboxGroup from '../../../src/modules/forms/tenonForm/CheckboxGroup';
 import RadioGroup from '../../../src/modules/forms/tenonForm/RadioGroup';
-import {validator} from '../../../src/modules/utils/helpers/validationHelpers';
-import {isRequired, isLongerThan} from '../../../src/modules/utils/data/validation';
+import { validator } from '../../../src/modules/utils/helpers/validationHelpers';
+import {
+    isRequired,
+    isLongerThan
+} from '../../../src/modules/utils/data/validation';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | The view components</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | The view components</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## The Tenon-UI view components
 
-<PageNav targets={
-    ['Usage',
-    'Common component props', 
-    'The Input component', 
-    'The TextArea component',
-    'The Select component',
-    'The Checkbox component',
-    'The CheckboxGroup component',
-    'The RadioGroup component']
-    } />
+<PageNav
+    targets={[
+        'Usage',
+        'Common component props',
+        'The Input component',
+        'The TextArea component',
+        'The Select component',
+        'The Checkbox component',
+        'The CheckboxGroup component',
+        'The RadioGroup component'
+    ]}
+/>
 
-### Usage 
+### Usage
 
 All view components can be used in one of two ways.
 
 #### The component prop
+
 Here is an example of using the `Input` component by using the `component` prop of the controller.
 
 ```
@@ -48,16 +56,17 @@ Here is an example of using the `Input` component by using the `component` prop 
 ```
 
 Note that the `labelText` prop for the `view component` is added to the `controller component` which
-will then pass these props through to the `view component`. This **ONLY** happens when 
+will then pass these props through to the `view component`. This **ONLY** happens when
 you use the `component` prop.
 
 This method is recommended when using a view component, even if you have created it yourself,
-and will be used further on this page. 
+and will be used further on this page.
 
 #### The children render prop
+
 You can still use the view components in the `children render prop` of the controllers.
 
-Here is an example of using the `Input` component to show how all view components can be 
+Here is an example of using the `Input` component to show how all view components can be
 used inside the `children render prop` of each controller:
 
 ```
@@ -75,25 +84,27 @@ used inside the `children render prop` of each controller:
 </Form.TextInputController>
 ```
 
-It is **VERY** important to spread the props object from the render function of the 
-`controller` onto the `view component`. This passes the required props into 
+It is **VERY** important to spread the props object from the render function of the
+`controller` onto the `view component`. This passes the required props into
 our view components. The same props you would otherwise use when creating your own views.
 
 ### Common component props
 
 #### labelText
+
 Required when present. Not used for `RadioGroup` and `CheckboxGroup`.
 
 Every form control needs a text label. With this prop you provide the text that will be rendered inside
 the `<label>` element.
 
 #### labelProps
+
 Not used for `RadioGroup` and `CheckboxGroup`.
 
-This is an optional object that can be used to override or amend the props that passed to the 
+This is an optional object that can be used to override or amend the props that passed to the
 `<label>` element.
 
-For example, if you want to add a specific `className` to the `<label>` of the `<textarea>` element 
+For example, if you want to add a specific `className` to the `<label>` of the `<textarea>` element
 you can do this:
 
 ```
@@ -101,13 +112,14 @@ you can do this:
     name="petDescription"
     labelText="Describe your pet"
     labelProps={{
-        className: 'special-label-class'            
+        className: 'special-label-class'
     }}
     component={TextArea}
 />
 ```
 
 #### contentHintText
+
 Every form control can also have `content hint text`. This is text that describes what should be
 entered into the control. For example, an input that requires at least five characters.
 
@@ -120,7 +132,7 @@ Specify a content hint text as follows:
 <Form.TextInputController
     name="petName"
     labelText="Name of pet"
-    contentHintText="The pet's name should be longer than three characters" 
+    contentHintText="The pet's name should be longer than three characters"
     component={Input}
 />
 ```
@@ -133,21 +145,18 @@ Content hints are rendered as follows:
     }}
 >
     {() => (
-    <>
-        <Form.TextInputController
-            name="petName"
-            validators={[
-                validator(
-                    isLongerThan(3), 
-                    'The name is too short'
-                )
-            ]}
-            labelText="Pet name"
-            contentHintText="The name should be longer than 3 characters"
-            component={Input}                    
-        />
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.TextInputController
+                name="petName"
+                validators={[
+                    validator(isLongerThan(3), 'The name is too short')
+                ]}
+                labelText="Pet name"
+                contentHintText="The name should be longer than 3 characters"
+                component={Input}
+            />
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>
 
@@ -156,35 +165,38 @@ is linked to the `<input>` element with the `aria-describedby` property. This is
 for screen readers.
 
 #### requiredText
+
 With this prop you can set the text that displays next to the `<label>` text for required fields.
 
 If you do not set this, a `*` will be shown for required fields as this is a standard pattern
 on the web. If you use this, please put a legend somewhere on your form that indicates that a
-`*` denotes a required field. 
+`*` denotes a required field.
 
 You don't have to do any more than that as `Tenon-UI` already marks required fields in a way
-that screen readers can interpret. 
+that screen readers can interpret.
 
 #### Tenon-UI specific props
 
-Should you look at the code for the view components, you will see that it also expects a number 
+Should you look at the code for the view components, you will see that it also expects a number
 of other props. These are the props that is provided by the `smart controller components` as
-seen in the examples above. 
+seen in the examples above.
 
 Please do not provide these props yourself as this will most probably break the functionality of
 the component.
 
 #### Other props
+
 Not relevant for `RadioGroup` and `CheckboxGroup`.
 
 Any other props given to these components will be passed onto the relevant functional HTML element.
 
 #### Refs
+
 In some case you may want to create a [React ref](https://reactjs.org/docs/refs-and-the-dom.html)
 to the form controls.
 
-In accessible applications, this is mostly done in cases where you want to set focus to a specific 
-element. 
+In accessible applications, this is mostly done in cases where you want to set focus to a specific
+element.
 
 Each view component [forwards the ref](https://reactjs.org/docs/forwarding-refs.html) to the the correct element so that you can easily set focus
 when required:
@@ -203,12 +215,13 @@ this.inputRef = React.createRef();
 ```
 
 **Note**: If you want to create a `ref` to any of the view components, you **HAVE** to use
-the `children render prop` version. Otherwise you will get a reference to the instance of 
+the `children render prop` version. Otherwise you will get a reference to the instance of
 the controller component class!
 
 ### The Input component
 
 As already illustrated above, the input component is used as:
+
 ```
 import { Form, Input, validator } from '@tenon-io/tenon-ui';
 
@@ -225,7 +238,7 @@ import { Form, Input, validator } from '@tenon-io/tenon-ui';
     ]}
      requiredText="( required )"
      labelText="Pet type"
-     componen={Input}           
+     componen={Input}
 />
 
 //...
@@ -239,37 +252,36 @@ Using this inside the `Form` component gives:
     }}
 >
     {() => (
-    <>
-        <Form.TextInputController
-            name="petType"
-            required="true"
-            validators={[
-                validator(
-                    isRequired,
-                    'A type of pet is required'
-                )
-            ]}
-            requiredText="( required )"
-            labelText="Pet type"
-            component={Input}
-        />
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.TextInputController
+                name="petType"
+                required="true"
+                validators={[
+                    validator(isRequired, 'A type of pet is required')
+                ]}
+                requiredText="( required )"
+                labelText="Pet type"
+                component={Input}
+            />
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>
 
 #### Overriding the input type
+
 By default an `<input type="text">` will be rendered. But this can also be overridden.
 
 The `TextInputController` will also play nice with other types.
 
 Override it like this:
+
 ```
 <Form.TextInputController
     name="petAge"
     labelText="Age of pet"
     type="number"
-    contentHintText="The pet's name should be longer than three characters" 
+    contentHintText="The pet's name should be longer than three characters"
 />
 ```
 
@@ -306,20 +318,23 @@ Using this inside the `Form` component gives:
     }}
 >
     {() => (
-    <>
-        <Form.TextareaController
-            name="petDescription"
-            required="true"
-            validators={[
-                validator(isRequired, 'A description of your pet is required')
-            ]}
-            requiredText="( required )"
-            labelText="Pet description"
-            rows="10"
-            component={TextArea}
-        />
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.TextareaController
+                name="petDescription"
+                required="true"
+                validators={[
+                    validator(
+                        isRequired,
+                        'A description of your pet is required'
+                    )
+                ]}
+                requiredText="( required )"
+                labelText="Pet description"
+                rows="10"
+                component={TextArea}
+            />
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>
 
@@ -328,7 +343,7 @@ Using this inside the `Form` component gives:
 The `Select` component needs `options` and those are provided as `children` of the component
 in the same way they would be coded in normal HTML.
 
-As we suggest passing it into the `component` prop of the `SelectController`, you can now 
+As we suggest passing it into the `component` prop of the `SelectController`, you can now
 code the `<option>` elements as children of the controller as they are passed as `children` to
 the component injected into the `component` prop.
 
@@ -352,7 +367,7 @@ import { Form, Select, validator } from '@tenon-io/tenon-ui';
         </option>
         <option value="1">
             One
-        </option>        
+        </option>
         <option value="2">
             Two
         </option>
@@ -372,32 +387,24 @@ Using this inside the `Form` component gives:
     }}
 >
     {() => (
-    <>
-        <Form.SelectController
-            name="petNumber"
-            required="true"
-            validators={[
-                validator(isRequired, 'Please select a numer of pets')
-            ]}
-            requiredText="( required )"
-            labelText="How many pets do you have?"
-            component={Select}
-        >
-        <option>
-            Select a number
-        </option>
-        <option value="1">
-            One
-        </option>        
-        <option value="2">
-            Two
-        </option>
-        <option value="3">
-            Three
-        </option>
-        </Form.SelectController>
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.SelectController
+                name="petNumber"
+                required="true"
+                validators={[
+                    validator(isRequired, 'Please select a numer of pets')
+                ]}
+                requiredText="( required )"
+                labelText="How many pets do you have?"
+                component={Select}
+            >
+                <option>Select a number</option>
+                <option value="1">One</option>
+                <option value="2">Two</option>
+                <option value="3">Three</option>
+            </Form.SelectController>
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>
 
@@ -418,7 +425,7 @@ import { Form, Checkbox, validator } from '@tenon-io/tenon-ui';
     required="true"
     validators={[
         validator(
-            value => value === true, 
+            value => value === true,
             'Please accept the terms and conditions'
         )
     ]}
@@ -438,19 +445,22 @@ Using this inside the `Form` component gives:
     }}
 >
     {() => (
-    <>
-        <Form.CheckboxController
-            name="acceptTerm"
-            required="true"
-            validators={[
-                validator(value => value === true, 'Please accept the terms and conditions')
-            ]}
-            requiredText="( required )"
-            labelText="Do you accept the terms and conditions?"
-            component={Checkbox}
-        />
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.CheckboxController
+                name="acceptTerm"
+                required="true"
+                validators={[
+                    validator(
+                        value => value === true,
+                        'Please accept the terms and conditions'
+                    )
+                ]}
+                requiredText="( required )"
+                labelText="Do you accept the terms and conditions?"
+                component={Checkbox}
+            />
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>
 
@@ -461,14 +471,16 @@ Use this component if you want to render a group of related checkboxes.
 Aside from the standard props for `Tenon-UI` view components, this component also accepts the following.
 
 #### legend
+
 This prop is required.
 
 Use this to set the `<legend>` for the group of checkboxes. This acts as a grouping label.
 
 #### options
+
 This prop is required.
 
-Use this to provide an options object to the component. This will be used to automatically render 
+Use this to provide an options object to the component. This will be used to automatically render
 a group of checkboxes based on this object. The object is an indexer object:
 
 ```
@@ -494,7 +506,7 @@ import { Form, CheckboxGroup, validator } from '@tenon-io/tenon-ui';
     required="true"
     validators={[
         validator(
-            value => value.length > 0, 
+            value => value.length > 0,
             'Please select at least one eating time.'
         )
     ]}
@@ -512,34 +524,34 @@ import { Form, CheckboxGroup, validator } from '@tenon-io/tenon-ui';
 ```
 
 Using this inside the `Form` component gives:
- 
+
 <Form
     onSubmit={submitData => {
         alert(JSON.stringify(submitData));
     }}
 >
     {() => (
-    <>
-        <Form.CheckboxGroupController
-            name="eatingTimes"
-            required="true"
-            validators={[
-                validator(
-                    value => value.length > 0, 
-                    'Please select at least one eating time.'
-                )
-            ]}
-            options ={{
-                morning: 'In the morning',
-                noon: 'At noon',
-                night: 'At night'
-            }}
-            requiredText="( required )"
-            legend="When does your pet eat?"
-            component={CheckboxGroup}
-        />
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.CheckboxGroupController
+                name="eatingTimes"
+                required="true"
+                validators={[
+                    validator(
+                        value => value.length > 0,
+                        'Please select at least one eating time.'
+                    )
+                ]}
+                options={{
+                    morning: 'In the morning',
+                    noon: 'At noon',
+                    night: 'At night'
+                }}
+                requiredText="( required )"
+                legend="When does your pet eat?"
+                component={CheckboxGroup}
+            />
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>
 
@@ -549,19 +561,21 @@ from all other controllers in `Tenon-UI`.
 
 ### The RadioGroup component
 
-Use this component if you want to render a group of radio buttons. 
+Use this component if you want to render a group of radio buttons.
 
 Aside from the standard props for `Tenon-UI` view components, this component also accepts the following.
 
 #### legend
+
 This prop is required.
 
 Use this to set the `<legend>` for the group of radio buttons. This acts as a grouping label.
 
 #### options
+
 This prop is required.
 
-Use this to provide an options object to the component. This will be used to automatically render 
+Use this to provide an options object to the component. This will be used to automatically render
 a group of radio buttons based on this object. The object is an indexer object:
 
 ```
@@ -587,7 +601,7 @@ import { Form, RadioGroup, validator } from '@tenon-io/tenon-ui';
     required="true"
     validators={[
         validator(
-            isRequired, 
+            isRequired,
             'Please select a colour.'
         )
     ]}
@@ -605,33 +619,28 @@ import { Form, RadioGroup, validator } from '@tenon-io/tenon-ui';
 ```
 
 Using this inside the `Form` component gives:
- 
+
 <Form
     onSubmit={submitData => {
         alert(JSON.stringify(submitData));
     }}
 >
     {() => (
-    <>
-        <Form.RadioGroupController
-            name="petColour"
-            required="true"
-            validators={[
-                validator(
-                    isRequired, 
-                    'Please select a colour.'
-                )
-            ]}
-            options ={{
-                 black: 'Black',
-                 white: 'White',
-                 brown: 'Brown'
-            }}
-            requiredText="( required )"
-            legend="What colour is your pet?"
-            component={RadioGroup}
-        />
-        <button type="submit">Submit</button>
-     </>   
+        <>
+            <Form.RadioGroupController
+                name="petColour"
+                required="true"
+                validators={[validator(isRequired, 'Please select a colour.')]}
+                options={{
+                    black: 'Black',
+                    white: 'White',
+                    brown: 'Brown'
+                }}
+                requiredText="( required )"
+                legend="What colour is your pet?"
+                component={RadioGroup}
+            />
+            <button type="submit">Submit</button>
+        </>
     )}
 </Form>

--- a/www/src/pages/forms.mdx
+++ b/www/src/pages/forms.mdx
@@ -1,43 +1,43 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Smart form components</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Smart form components</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Smart form components
 
-The set of `Tenon-UI smart form components` strive to make data management, validation and 
+The set of `Tenon-UI smart form components` strive to make data management, validation and
 accessibility a very manageable task in React applications.
 
 Used together these components will:
 
 1. Automatically manage the data entered in the form and expose that to you through submit events.
 1. Provide you with an easy to manage hierarchical validation engine that allows you to easily add
-your own validators and error messages.
+   your own validators and error messages.
 1. Provide you with everything you need to ensure that each form and form field is accessible.
-
 
 Follow these steps to create powerful, accessible forms with `Tenon-ui`:
 
 1. If the terms `render props` and `prop getters` are not yet clear, visit the [Reguired knowledge page](/forms-knowledge).
-1. Learn how to [replace your form elements](/forms-form-component) with the `Form component`. 
-1. [Learn about our smart controllers](/forms-smart-controllers) and how they provide data, validation and 
-accessibility management. 
+1. Learn how to [replace your form elements](/forms-form-component) with the `Form component`.
+1. [Learn about our smart controllers](/forms-smart-controllers) and how they provide data, validation and
+   accessibility management.
 1. Then learn how to create form elements with `Tenon-UI` by [using the view components](/forms-view-components).
-1. Finally see how you can construct complex forms with accessible validation using the 
-[ErrorBlock component](/forms-error-block)
+1. Finally see how you can construct complex forms with accessible validation using the
+   [ErrorBlock component](/forms-error-block)
 
 ## Want to create your own view?
 
 Every view component on the `Tenon-UI` smart form is completely replaceable.
- 
-If you want to create your own view simply make direct use of the `prop getter` functions 
+
+If you want to create your own view simply make direct use of the `prop getter` functions
 as well as other props provided by the `smart controllers`.
 
 You can create views for:
@@ -49,12 +49,13 @@ You can create views for:
 1. [Groups of checkboxes or radiobuttons](/forms-create-your-own-checkboxgroup-radiogroup-view)
 
 ### Disclaimer
+
 The `smart controllers` provide all the function to create fully accessible form controls, however,
 this needs to be backed up with an accessible HTML view. We can therefore not guarantee that
 every view rendered with `Tenon-UI` will be accessible unless the supplied view components are
 used or mimicked exactly in terms of HTML function.
- 
-Feel free to mix up the HTML but ensure that all elements are present and that the prop getters are 
+
+Feel free to mix up the HTML but ensure that all elements are present and that the prop getters are
 applied correctly.
- 
-And be sure to test with screen readers. 
+
+And be sure to test with screen readers.

--- a/www/src/pages/getting-started.mdx
+++ b/www/src/pages/getting-started.mdx
@@ -1,14 +1,16 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import Tabs from '../../../src/modules/tabs/Tabs';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Getting started</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Getting started</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Getting started
 
@@ -27,7 +29,3 @@ npm install @tenon-io/tenon-ui
 ```javascript
 yarn add @tenon-io/tenon-ui
 ```
-
-
-
-

--- a/www/src/pages/headings.mdx
+++ b/www/src/pages/headings.mdx
@@ -1,19 +1,20 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Headings</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Headings</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Headings
 
-The hierarchy of headings is very important. Heading elements (`<h1> - <h6>`) are not there to provide 
-different styles. They are there to provide structure to your application. 
+The hierarchy of headings is very important. Heading elements (`<h1> - <h6>`) are not there to provide
+different styles. They are there to provide structure to your application.
 
 Headings are to be used in order and levels should not be skipped.
 
@@ -38,7 +39,7 @@ Example HTML:
 ```
 
 This can seem simple enough until we use it in a complex React application. Because
-of component composition and re-use it can be hard to anticipate which `<h>` element 
+of component composition and re-use it can be hard to anticipate which `<h>` element
 to use.
 
 ### The Heading component
@@ -61,7 +62,7 @@ If used by itself, it will always render an `<h1>` element.
 
 #### Heading.LevelBoundary
 
-To allow automatic level calculation, use the `Heading.LevelBoundary` component. 
+To allow automatic level calculation, use the `Heading.LevelBoundary` component.
 
 This component is applied every time a new level should be used in the wrapped code:
 
@@ -105,10 +106,10 @@ If you want change this, you can use the `levelOverride` prop:
         I will be an h3
     </Heading.H>
 </Heading.LevelBoundary>
-```  
+```
 
 This allows for fine tuning the heading level, should the defaults not be enough or if you
-are using it in a section of an application not fully driven by this component. 
+are using it in a section of an application not fully driven by this component.
 
 ### Component using Header
 

--- a/www/src/pages/index.mdx
+++ b/www/src/pages/index.mdx
@@ -1,33 +1,35 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Home page</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Home page</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Welcome to Tenon-UI
 
 These are the documentation pages of `Tenon-UI`: Tenon's accessible React components library.
 
-### Why another component library? 
+### Why another component library?
 
 Tenon-UI strives to become a go-to library for React developers who want to build inclusive and
 accessible sites that can be used by as many people as possible.
 
-If you do not yet know why this is a very good idea or how this relates to React in general, 
+If you do not yet know why this is a very good idea or how this relates to React in general,
 please visit the [React Accessibility Docs](https://reactjs.org/docs/accessibility.html).
 
 ### Use our views or bring your own.
 
 Not every project calls for the same visual representation, and we acknowledge that. So Tenon-UI has
-been built with this in mind. 
+been built with this in mind.
 
 All visual parts of the library are completely plug and play allowing you to implement your own
-view, if required. 
+view, if required.
 
 Tenon-UI also comes with its own separate `StyleSheet` and `SASS` source files so you can change
 it or even replace it completely.
@@ -38,21 +40,21 @@ We want to make it as easy as possible for you to build powerful, accessible app
 
 With great power comes great responsibility.
 
-We have gone through a lot of effort to ensure that this library conforms to current 
+We have gone through a lot of effort to ensure that this library conforms to current
 accessibility requirements, working on as wide a range of browsers and assistive technologies
 as possible.
 
-With this in mind, the view components shipped with the library play a crucial 
+With this in mind, the view components shipped with the library play a crucial
 role to ensure this feature.
 
 If you do decide to replace our view components with your own, **we can no longer guarantee an
 accessible result**. We recommend that you just use our views.
 
-If you still want to replace our view components, please first read the documentation and 
-supporting linked information carefully. Also have a look at how our view 
+If you still want to replace our view components, please first read the documentation and
+supporting linked information carefully. Also have a look at how our view
 components are built and use them as a a guideline for your own.
 
-### Enjoy  
+### Enjoy
 
 Tenon-UI exists to make your life easier. Please enjoy the productivity boost these
 components add.
@@ -60,7 +62,7 @@ components add.
 ### What about Hooks and Suspense?
 
 We are fully aware of the future path of React. So we will invest time in the near future to also
-bring support for `Hooks` and `Suspense` where appropriate. 
+bring support for `Hooks` and `Suspense` where appropriate.
 
 But first we want to provide you with components built on the current tried and tested patterns.
 

--- a/www/src/pages/notifications.mdx
+++ b/www/src/pages/notifications.mdx
@@ -1,14 +1,16 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import NotificationExample from '../components/examples/NotificationExample';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Notifications</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Notifications</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Notifications
 
@@ -73,12 +75,14 @@ is up to you.
 ### Notification component props
 
 #### isActive
+
 This prop is required.
 
 A boolean prop indicating if the content of the `Notification` component should be shown or
-hidden. 
+hidden.
 
 #### type
+
 This prop is required.
 
 A string prop indicating what type of notification you want to render:

--- a/www/src/pages/spinner-button.mdx
+++ b/www/src/pages/spinner-button.mdx
@@ -1,21 +1,23 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import SpinnerButtonExample from '../components/examples/SpinnerButtonExample';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Spinner button</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Spinner button</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Spinner button
 
 When you want to trigger an asynchronous action with a button and clearly indicate to all users that
-the action is busy and also that it has completed, you can use `Tenon-IU`'s `SpinnerButton`. 
+the action is busy and also that it has completed, you can use `Tenon-IU`'s `SpinnerButton`.
 
-It shows a visual spinner while marked as active and also broadcasts the necessary messages to screen 
+It shows a visual spinner while marked as active and also broadcasts the necessary messages to screen
 readers.
 
 ### Usage
@@ -81,26 +83,31 @@ Therefore the button remains clickable but the `SpinnerButton` component manages
 `onClick` handler is executed or not.
 
 #### isBusy
+
 This prop is required.
 
-A boolean value indicating if the action triggered by the button is busy. You are responsible 
+A boolean value indicating if the action triggered by the button is busy. You are responsible
 for linking this to your asynchronous action in the code.
 
-#### busyText 
+#### busyText
+
 A string value that will be broadcast to screen readers when the button is busy.
 
 #### completeText
+
 A string value that will be broadcast to screen readers when the button action completes.
 
 #### onBusyClick
+
 An event handler that always fires.
 
-You may want trigger an action if a user clicks on a button with a busy state. This allows you 
-to set notifications or other side effects of clicking on a busy button. You can use the 
-`onBusyClick` handler for that purpose as the `onClick` handler is only executed when the button is 
+You may want trigger an action if a user clicks on a button with a busy state. This allows you
+to set notifications or other side effects of clicking on a busy button. You can use the
+`onBusyClick` handler for that purpose as the `onClick` handler is only executed when the button is
 in a non-busy state.
 
 #### spinnerImgSrc
+
 An imported animated image source.
 
 If you do not like the spinner that `Tenon-UI` renders, you can provide your own by using this prop.

--- a/www/src/pages/spinner.mdx
+++ b/www/src/pages/spinner.mdx
@@ -1,18 +1,20 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import Spinner from '../../../src/modules/notifications/Spinner';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Spinner</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Spinner</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Spinner
 
-Visual aids can be very helpful in an application but for people who cannot see them they can 
+Visual aids can be very helpful in an application but for people who cannot see them they can
 sometimes seriously degrade the overall experience of the web application if these aids carry
 important information.
 
@@ -30,9 +32,9 @@ import { Spinner } from '@tenon-io/tenon-ui';
 
 //...
 
-<Spinner 
-    title="Busy fetching data" 
-    className="demo-spinner" 
+<Spinner
+    title="Busy fetching data"
+    className="demo-spinner"
 />
 ```
 
@@ -52,6 +54,7 @@ This will display as:
 ### Component props
 
 #### title
+
 This is required.
 
 A string value describing the spinner. Please use this to describe the purpose of the spinner,
@@ -60,6 +63,6 @@ such as "Busy fetching user data.".
 Without a proper title, such spinners are inaccessible to a large number of people.
 
 #### className
-You can use this to give a class to the internal `SVG` so that you can style it with `CSS` 
-as shown above.
 
+You can use this to give a class to the internal `SVG` so that you can style it with `CSS`
+as shown above.

--- a/www/src/pages/styling.mdx
+++ b/www/src/pages/styling.mdx
@@ -1,18 +1,20 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Styling</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Styling</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Styling
 
-Currently `Tenon-UI` comes with a compiled `style sheet` as well as `SASS` source files for you 
-to use. 
+Currently `Tenon-UI` comes with a compiled `style sheet` as well as `SASS` source files for you
+to use.
 
 You can use our compiled `CSS`, import and override our `SASS` files, or completely restyle the components
 using the classes rendered on the elements.
@@ -22,7 +24,7 @@ and non-intrusive as possible.
 
 ### The compiled stylesheet
 
-In your React app, simply import the `tenon-ui.css` file located in the `/lib/styles` part of 
+In your React app, simply import the `tenon-ui.css` file located in the `/lib/styles` part of
 the import:
 
 ```

--- a/www/src/pages/tabs.mdx
+++ b/www/src/pages/tabs.mdx
@@ -1,18 +1,20 @@
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 import Layout from '../components/Layout';
 import Tabs from '../../../src/modules/tabs/Tabs';
 
-export default ({children}) => 
-<Layout>
-    <Helmet>
-        <title>Tenon-ui | Tabbed interface</title>
-    </Helmet>{children}
-</Layout>
+export default ({ children }) => (
+    <Layout>
+        <Helmet>
+            <title>Tenon-ui | Tabbed interface</title>
+        </Helmet>
+        {children}
+    </Layout>
+);
 
 ## Tabbed interface
 
-Rendering accessible tabbed interfaces is not simple. There are a number of features that you 
+Rendering accessible tabbed interfaces is not simple. There are a number of features that you
 need to implement if you want all users to be able to easily interact with your tabs.
 
 You can read more about this on [the W3C ARIA design patterns page for tabs](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)
@@ -67,7 +69,7 @@ You then get:
 
 You are free to render any view you'd like inside the tabs.
 
-**Please note**: True tabs are not site navigation elements. If you are rendering large 
+**Please note**: True tabs are not site navigation elements. If you are rendering large
 views inside your tabs, rather consider doing it with routing and navigation elements. `Tenon-UI`
 uses styles to hide and show the tabs, so rendering very large content in many tabs will
 incur a performance hit.
@@ -75,53 +77,59 @@ incur a performance hit.
 ### Tabs.Tab component props
 
 #### title
+
 This prop is required.
 
 The title of the panel. This is the text that is rendered as the text inside the tabs. By default,
 it is also rendered as heading of the tab panel.
 
 #### noHeading
-This boolean prop can be used if you do not want to render the `title` texts as a heading inside the 
+
+This boolean prop can be used if you do not want to render the `title` texts as a heading inside the
 tab panel.
 
 #### className
+
 This prop is passed through to the wrapping `<section>` element of the tab panel.
 
 #### headingLevel
-The `Tabs` component makes use of the [Tenon-UI Heading component](/headings) to automatically
-render the correct heading level. 
 
-If your application does not use this component you can override the default level by giving the 
+The `Tabs` component makes use of the [Tenon-UI Heading component](/headings) to automatically
+render the correct heading level.
+
+If your application does not use this component you can override the default level by giving the
 desired heading level in this prop.
 
 ```
-<Tabs.Tab 
+<Tabs.Tab
     title="Panel 4"
     headingLevel="3">
     <p>You are on panel 4.</p>
 </Tabs.Tab>
-``` 
+```
 
 #### name
-A string name prop that can be used to identify the tabs by name. This can be useful in the 
+
+A string name prop that can be used to identify the tabs by name. This can be useful in the
 toggle render function described next.
 
 If no `name` prop is given the tabs are named by index: `tab0`, `tab1`, `tab3` ... etc.
 
 #### toggleRender
+
 Should you also want to customise the HTML that is rendered inside the tab toggle elements,
-you can pass a render function into this prop. This will then override the default HTML inside 
+you can pass a render function into this prop. This will then override the default HTML inside
 the toggles.
 
 ```
-<Tabs.Tab 
-    title="Panel 1" 
-    name="myTab" 
+<Tabs.Tab
+    title="Panel 1"
+    name="myTab"
     toggleRender={
-    ({isActive, name, title}) => 
-        isActive ? 
-            <b>{title}</b> : 
-            <span className={name}>{title}</b> 
+    ({isActive, name, title}) =>
+        isActive ?
+            <b>{title}</b> :
+            <span className={name}>{title}</b>
     JSON.stringify(props)
     }>
     <p>You are on panel 1.</p>
@@ -131,12 +139,14 @@ the toggles.
 The render function is called with:
 
 ##### title
+
 The text title of the tab so that you can render that text into your own JSX.
 
 ##### name
-The name given to the tab in question. This can be handy in some cases where generic render 
+
+The name given to the tab in question. This can be handy in some cases where generic render
 functions are used.
 
 ##### isActive
-A boolean value indicating if the tab is currently active.
 
+A boolean value indicating if the tab is currently active.

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -777,27 +777,25 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mdx-js/mdx@^0.15.5":
-  version "0.15.5"
-  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-0.15.5.tgz#a3821a1e0e460ee993437ef3f922482fb67c31d0"
-  integrity sha512-BZQztjePZNLLbtqTdI8ApzUl1I6blY94vCswT/TYvH305Uw86t+p1mzP2R8RNe7SWT3icLkfiwRAIDM9Zp52xw==
+"@mdx-js/mdx@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-0.16.0.tgz#eb5b908d4903dc657c1921090bae1173166553a2"
+  integrity sha512-HCsRMmDOHmsTfwRxXOovccfk2DCVd4Y7mn9nP5U8R3piIBFw73/Ayb9HoTdyvWnSX66kZkX0nTRnmWGOgT3u0g==
   dependencies:
     change-case "^3.0.2"
+    detab "^2.0.0"
     mdast-util-to-hast "^3.0.0"
     remark-parse "^5.0.0"
     remark-squeeze-paragraphs "^3.0.1"
     to-style "^1.3.3"
     unified "^6.1.6"
+    unist-builder "^1.0.1"
     unist-util-visit "^1.3.0"
 
-"@mdx-js/tag@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-0.15.0.tgz#a98949206cc21b27a56a11550b41229631eb8b1c"
-  integrity sha512-W5HVjced5SMJDoV56aVkZjIfTRM/R1RBpdcDdHMdoza0rSU6lorj7xM5VJtD1AMYRRFuDUu2idkuAJaNosO4Gw==
-  dependencies:
-    create-react-context "^0.2.2"
-    hoist-non-react-statics "^2.5.5"
-    prop-types "^15.6.1"
+"@mdx-js/tag@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-0.16.0.tgz#a676132203a484b575c8837cd24dea5e02e91beb"
+  integrity sha512-Myz+KO7IlbWE+ZLcVvqxEGQMbQMOBrblb/j20r1+FOrftHdzDM4f1BFBlmc8ZVjjz07emJWYP0P8o13/1BNZbw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -823,10 +821,10 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@tenon-io/tenon-codeblock@^1.0.0-RC.2":
-  version "1.0.0-RC.2"
-  resolved "https://registry.yarnpkg.com/@tenon-io/tenon-codeblock/-/tenon-codeblock-1.0.0-RC.2.tgz#9f3202d5e349e90cee8c889154dec379069d45f4"
-  integrity sha512-9vyHHUozQyY86Vumrpev7Watu7w0TETpk2ty9Z0wuarftfhx+djB1TlfBuB1mujXml0oVavtESqJlS1ONEGHog==
+"@tenon-io/tenon-codeblock@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tenon-io/tenon-codeblock/-/tenon-codeblock-1.0.0.tgz#03c7769e35d96eef94e0dbe68efe841c1e0c54f5"
+  integrity sha512-p/DgfSCq1r5ROkom77grFn+6m/sdUP1p7JFpLDeF7FAlP9uZDeJyOJ8hpDvT79nJTchMH0CllveDme0R1Y7cHw==
   dependencies:
     "@babel/runtime" "7.1.2"
     axios "0.18.0"
@@ -3026,7 +3024,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.2.1, create-react-context@^0.2.2:
+create-react-context@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
@@ -5453,7 +5451,7 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.5:
+hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,10 +8479,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
-  integrity sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==
+prettier@1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+  integrity sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==
 
 pretty-error@^2.0.2:
   version "2.1.1"
@@ -8808,15 +8808,15 @@ react-deep-force-update@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
   integrity sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw=
 
-react-dom@16.6.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.0.tgz#6375b8391e019a632a89a0988bce85f0cc87a92f"
-  integrity sha512-Stm2D9dXEUUAQdvpvhvFj/DEXwC2PAL/RwEMhoN4dvvD2ikTlJegEXf97xryg88VIAU22ZAP7n842l+9BTz6+w==
+react-dom@16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
+  integrity sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.10.0"
+    scheduler "^0.11.2"
 
 react-i18next@7.10.1:
   version "7.10.1"
@@ -8879,15 +8879,15 @@ react-transform-hmr@1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@16.6.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.0.tgz#b34761cfaf3e30f5508bc732fb4736730b7da246"
-  integrity sha512-zJPnx/jKtuOEXCbQ9BKaxDMxR0001/hzxXwYxG8septeyYGfsgAei6NgfbVgOhbY1WOP2o3VPs/E9HaN+9hV3Q==
+react@16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
+  integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.10.0"
+    scheduler "^0.11.2"
 
 read-only-stream@^2.0.0:
   version "2.0.0"
@@ -9504,10 +9504,10 @@ sax@^1.2.4, sax@~1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.10.0.tgz#7988de90fe7edccc774ea175a783e69c40c521e1"
-  integrity sha512-+TSTVTCBAA3h8Anei3haDc1IRwMeDmtI/y/o3iBe3Mjl2vwYF9DtPDt929HyRmV/e7au7CLu8sc4C4W0VOs29w==
+scheduler@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+  integrity sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This fixes the issue where supplying a user `onChange` handler breaks the controlled components.

Also bumped `Prettier` to allow for full styling.

Also bumped `MDX` packages to allow `MDX` styling with `Prettier`.

Closes #15 