### PR TITLE
added minor grammar fixes in header docs

### DIFF
--- a/www/src/pages/headings.mdx
+++ b/www/src/pages/headings.mdx
@@ -44,13 +44,13 @@ to use.
 
 ### The Heading component
 
-The `Tenon-UI` heading component handles automatic calculation of heading levels for you.
+The `Tenon-UI` heading component handles the automatic calculation of heading levels for you.
 
-The component is composite and contains to sub components:
+The component is composite and contains to sub-components:
 
 #### Heading.H
 
-This component replace the standard `<h>` elements, but it used in exactly the same way:
+This component replaces the standard `<h>` elements, but it is used in exactly the same way:
 
 ```
 <Heading.H>
@@ -108,7 +108,7 @@ If you want change this, you can use the `levelOverride` prop:
 </Heading.LevelBoundary>
 ```
 
-This allows for fine tuning the heading level, should the defaults not be enough or if you
+This allows for fine-tuning the heading level, should the defaults not be enough or if you
 are using it in a section of an application not fully driven by this component.
 
 ### Component using Header


### PR DESCRIPTION
There were some minor grammar errors in the header docs . 

This PR fixes these errors . 

